### PR TITLE
Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you're not inclined to make PRs you can tweet me at ```@ripienaar```
 ## Tools for teams
 
   * https://www.flowdock.com/ - Chat and inbox, free for teams of 5 or less
-
+  * https://slack.com - Free for unlimited users with some feature limitations
 
 ## Code Quality
 


### PR DESCRIPTION
Feels like it fits under here and they have a 'Lite' plan which is free (slack.com/pricing) and perfectly suitable for getting started with limitations placed on the # of integrations and # of messaged retained in the search index.

About 60% of the teams I'm joined to are using the Lite plan and don't pay. Seems to work for them.

Thoughts or comments?