### PR TITLE
Update gitter description with new free plan info

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you're not inclined to make PRs you can tweet me at ```@ripienaar```
   * https://www.flowdock.com/ - Chat and inbox, free for teams of 5 or less
   * https://slack.com - Free for unlimited users with some feature limitations
   * https://hipchat.com - Free for unlimited users with some feature limitations
-  * https://gitter.im - "Chat, for GitHub". Free for public rooms.
+  * https://gitter.im - "Chat, for GitHub". Unlimited public & private rooms, free for teams of up to 25
   * http://www.google.com/hangouts/ - One place for all your Conversations, for free (Need Google Account)
   * https://kato.im - Team Chat & Collaboration, free for unlimited users with some feature limitations
 


### PR DESCRIPTION
Gitter is now free for teams of up to 25
http://blog.gitter.im/2015/03/31/free-for-teams-of-up-to-25/