### PR TITLE
Adding logstash in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ If you're not inclined to make PRs you can tweet me at ```@ripienaar```
   * https://logentries.com/ - Free up to 5GB/month with 7 day retention
   * https://www.loggly.com/ - Free for a single user, see the ```lite``` option
   * http://sematext.com/logsene - Free for 1M logs, unlimited retention
+  * http://logstash.net/ - Free and open sourced. Apache 2.0 License
 
 ## Analytics
 


### PR DESCRIPTION
Added Logstash (http://logstash.net/) in log management list. 
Its free and open sourced with Apache 2.0 License.