### PR TITLE
Nitrous.io change of policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Table of Contents
 
    * https://c9.io - IDE in a browser. Incorporates an Ubuntu virtual machine and in-browser terminal access. Integrates with github and bitbucket, but also adds SFTP and generic Git access.
    * https://koding.com - IDE in a browser. Features: Full sudo access - VMs hosted on Amazon EC2 - SSH Access - Real EC2 VM, no LXCs/hypervising - Custom sub-domains - Publicly accessible IP - Ubuntu 14.04 - IDE/Terminal/Collaboration
-   * https://www.nitrous.io - Private Linux instance(s) with interactive collaboration {[More Details](http://goo.gl/J1Zbsg)}
+   * https://www.nitrous.io - Private Linux instance(s) with interactive collaboration, free for 2 hours a day. {[More Details](http://goo.gl/J1Zbsg)}
    * http://visualstudio.com/free - Fully-featured IDE with thousands of extensions, cross-platform app development (Microsoft extensions available for download for iOS and Android), desktop, web and cloud development, multi-language support (C#, C++, JavaScript, Python, PHP and more).
    * https://cloud.sagemath.com - Collaborative mathematics-oriented IDE in a browser, with support for Python, LaTeX, IPython Notebooks, etc.
    * https://wakatime.com - quantified self metrics about your coding activity, using text editor plugins - Limited plan for free.


### PR DESCRIPTION
Nitrous.io are phasing out the free tier as it stands.

Instead, the new free tier will be 2 hours per day.