### PR TITLE
Adding Avalara to Payment / Billing Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Table of Contents
 ## Payment / Billing Integration
 
  * https://www.braintreepayments.com - Credit Card, Paypal, Venmo, Bitcoin, Apple Pay (, ...) integration. Single and Recurrent Payments. First $50 are free of charge.
+ * http://taxratesapi.avalara.com/ - Get the right sales tax rates to charge for the close to 10,000 sales tax jurisdictions in the USA. Free REST API. Registration required.
 
 ## Other Packs
 


### PR DESCRIPTION
Avalara has a free REST API for determining the correct sales tax, using zip codes or street address (for more precision). Figured the Payment / Billing Integration area is appropriate.

Full Disclosure: I'm an Avalara evangelist.