### PR TITLE
Updated SendGrid free availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Table of Contents
   * http://www.mailgun.com/ - First 10,000 emails per month are free
   * http://mailchimp.com/ - 2,000 subscribers and 12,000 emails per month are free
   * https://sendloop.com/ - 2,000 subscribers and 10,000 email delivery every month is free
-  * http://sendgrid.com/ - 400 emails per day for free/25,000 free transactional emails per month for emails sent from a Google compute instance
+  * http://sendgrid.com/ - 400 emails per day for free/25,000 free transactional emails per month for emails sent from a Google compute instance or Microsoft Azure App Service
   * http://mandrill.com/ - First 12,000 emails per month are free
   * https://www.phplist.com/ - Hosted version allow 300 mails per month for free
   * https://www.mailjet.com/ - 6000 mails per month for free


### PR DESCRIPTION
Microsoft Azure offers the same 25,000 emails per month for free with SendGrid. All you have to do is make an instance from the Azure Marketplace.