### PR TITLE
Added Bitdeli and GitHub Analytics Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Table of Contents
   * https://keen.io/ - Up to 50,000 events/month free
   * http://www.inspectlet.com/ - 100 sessions/month free for 1 website
   * https://www.mousestats.com/ - 100 sessions/month free for 1 website
+  * https://bitdeli.com/ - Unlimited free analytics
+
+**P.S. - GitHub also has its own analytic service. [Read Here](https://github.com/blog/1672-introducing-github-traffic-analytics)**
 
 ## Monitoring
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Table of Contents
   * https://www.mousestats.com/ - 100 sessions/month free for 1 website
   * https://bitdeli.com/ - Unlimited free analytics
 
-**P.S. - GitHub also has its own analytic service. [Read Here](https://github.com/blog/1672-introducing-github-traffic-analytics)**
 
 ## Monitoring
 


### PR DESCRIPTION
Added [Bitdeli](https://bitdeli.com) and [GitHub](https://github.com/blog/1672-introducing-github-traffic-analytics) Analytics service.