### PR TITLE
Revert "Added Bitdeli and GitHub Analytics Service"

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ Table of Contents
   * https://keen.io/ - Up to 50,000 events/month free
   * http://www.inspectlet.com/ - 100 sessions/month free for 1 website
   * https://www.mousestats.com/ - 100 sessions/month free for 1 website
-  * https://bitdeli.com/ - Unlimited free analytics
-
 
 ## Monitoring
 


### PR DESCRIPTION
Backing this out as the service is essentially broken due to github changes, if they figure out a deal with github or a work around they'd be welcome back.

See http://blog.bitdeli.com/post/77717727361/on-githubs-image-proxy

Reverts ripienaar/free-for-dev#342
