### PR TITLE
Added: http://inch-ci.org/ - Documentation badges for Ruby, JS & Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Table of Contents
   * https://www.codacy.com/ - Automated code reviews for PHP, Python, Javascript, Scala and CSS - free for open source
   * https://www.pullreview.com/ - Automated Code Review for Ruby in GitHub, Bitbucket and Gitlab - free for Open Source
   * http://gocover.io/ - Code coverage for any [Go](http://golang.org/) package
+  * http://inch-ci.org/ - Documentation badges for Ruby, JS & Elixir
 
 ## Code Search and Browsing
   * https://sourcegraph.com/ - Java, Go, Python, Node.js, etc., code search/cross-references - free for open source


### PR DESCRIPTION
Hi @ripienaar thanks for this list/repo!

Just a little patch in odred to add http://inch-ci.org/ (Documentation badges for Ruby, JS & Elixir)

Thanks!