### PR TITLE
Adding appenlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Table of Contents
   * https://bugsnag.com/ - Free for up to 2000 errors a month after the initial trial
   * https://airbrake.io/ - Automatically groups, organizes and notifies you about your application errors. Free plan - 7200 errors/day, 1 user, 1 project, 2 day retention.
   * http://getsentry.com/ - Sentry tracks app exceptions in realtime, has a small free plan. Free, unrestricted use if self-hosted.
+  * https://appenlight.com/ - Automatic error reporting, performance monitoring, in-app logging with team collaboration.
 
 ## Search
 


### PR DESCRIPTION
I've been using appenlight for many months now in the free plan setting, but they removed all information about pricing and plans from site, what remains is [this discussion](http://discuss.bootstrapped.fm/t/hi-im-marcin-from-appenlight-com/1711/2) with the following text:

Exceptional services start free
So you get one month of Pro plan on signup (No CC required).
After 30 days you can still use our free forever plan!

I believe they just removed the Pro plan for now, so all accounts are free.

