### PR TITLE
Per HP's announcement, HP Cloud will be terminated on January 31, 2016.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,6 @@ Table of Contents
   * https://cloud.google.com/appengine/ - Google App Engine gives 28 instance hours/day free, 1 GB NoSQL Database and more
   * https://www.engineyard.com/ - Engine Yard provides 500 free hours
   * http://azure.microsoft.com/ - MS Azure gives $200 worth of free usage for a trial
-  * http://hpcloud.com/ - $300 credit over 90 days
   * https://appharbor.com/ - A .Net PaaS that provides 1 free worker
   * https://shellycloud.com/ - Platform for hosting Ruby and Ruby on Rails apps. Shelly Cloud gives €20 free credit
   * https://www.heroku.com/ - Host your apps in the cloud, free for single process apps


### PR DESCRIPTION
Remove HP Cloud from list as they're killing it off.