### PR TITLE
Clean all markdown links

### DIFF
--- a/readme2.md
+++ b/readme2.md
@@ -165,8 +165,8 @@ Table of Contents
   * [tinfoilsecurity.com](https://tinfoilsecurity.com/) — Automated vulnerability scanning. Free plan = weekly XSS scans
   * [acunetix.com](http://acunetix.com/free-network-security-scanner/) — Free vulnerability and network scanning for 3 targets
   * [ponycheckup.com](https://ponycheckup.com/) — An automated security checkup tool for Django websites
-  * [foxpass.com](https://foxpass.com/) — Hosted LDAP and RADIUS. Easy per-user logins to servers, VPNs, and wireless networks. Free for 10 users
-  * [opswatgears.com](https://opswatgears.com/) — Security Monitoring of computers, devices, applications, configurations,... Free 25 users and 30 days history
+  * [foxpass.com](https://www.foxpass.com/) — Hosted LDAP and RADIUS. Easy per-user logins to servers, VPNs, and wireless networks. Free for 10 users
+  * [opswatgears.com](https://www.opswatgears.com/) — Security Monitoring of computers, devices, applications, configurations,... Free 25 users and 30 days history
   * [bitninja.io](https://bitninja.io/) — Botnet protection through a blacklist, free plan only reports limited information on each attack
   * [onelogin.com](https://onelogin.com/) — Identity as a Service (IDaaS), Single Sign-On Identity Provider, Cloud SSO IdP, 3 company apps and 5 personal apps, unlimited users
   * [logintc.com](https://logintc.com/) — Two-factor authentication (2FA) by push notifications, free for 10 users, VPN, Websites and SSH
@@ -182,7 +182,7 @@ Table of Contents
   * [logentries.com](https://logentries.com/) — Free up to 5 GB/month with 7 days retention
   * [loggly.com](https://loggly.com/) — Free for a single user, see the ```lite``` option
   * [sematext.com](http://sematext.com/logsene) — Free for 1 million logs, unlimited retention
-  * [sumologic.com](https://sumologic.com/) — Free up to 500 MB/day, 7 days retention
+  * [sumologic.com](https://www.sumologic.com/) — Free up to 500 MB/day, 7 days retention
 
 ## Translation Management
 
@@ -199,7 +199,7 @@ Table of Contents
   * [checkmy.ws](https://checkmy.ws/en/solutions/free-forever-for-foss/) — Free 15 days full demo and 3 websites, forever free for Open Source
   * [appneta.com](http://appneta.com/) — Free with 1 hour data retention
   * [thousandeyes.com](https://thousandeyes.com/) — Network and user experience monitoring. 3 locations, plus 20 data feeds of major web services free
-  * [datadoghq.com](https://datadoghq.com/) — Free for up to 5 nodes
+  * [datadoghq.com](https://www.datadoghq.com/) — Free for up to 5 nodes
   * [stackdriver.com](http://stackdriver.com/) — Free monitoring up to 10 servers/hosted services
   * [keymetrics.io](https://keymetrics.io/) — Free for 2 servers with 7 days data retention
   * [newrelic.com](http://newrelic.com/) — Free with 24 hours data retention
@@ -302,7 +302,7 @@ Table of Contents
   * [platform.telerik.com](https://platform.telerik.com/) — Build and deploy mobile applications using JavaScript. Free plan has 100 MB data storage, 1 GB file storage, 5 GB bandwidth, 1 million push notifications for BaaS offering, 100 active devices for analytics
   * [scn.sap.com](http://scn.sap.com/docs/DOC-56411) — The in-memory Platform-as-a-Service offering from SAP. Free developer accounts come with 1 GB structured, 1 GB unstructured, 1 GB of Git data and allow you to run HTML5, Java and HANA XS apps
   * [mendix.com](https://mendix.com/) — Rapid Application Development for Enterprises, unlimited number of free sandbox environments supporting 10 users, 100 MB of files and 100 MB database storage each
-  * [pythonanywhere.com](https://pythonanywhere.com/) — Cloud Python app hosting. Beginner account is free, 1 Python web application at your-username.pythonanywhere.com domain, 512 MB private file storage, one MySQL database
+  * [pythonanywhere.com](https://www.pythonanywhere.com/) — Cloud Python app hosting. Beginner account is free, 1 Python web application at your-username.pythonanywhere.com domain, 512 MB private file storage, one MySQL database
   * [configure.it](http://configure.it/) — Mobile app development platform, free for 2 projects, limited features but no resource limits
   * [stamplay.com](https://stamplay.com/) — 50 K API calls, 100 GB data transfer, and 1 GB storage for free
   * [qtcloudservices.com](http://qtcloudservices.com/products/managed-runtime/) — Managed platform with micro runtime instance and database for free
@@ -310,7 +310,7 @@ Table of Contents
   * [viaduct.io](https://viaduct.io/) — 350 MB of RAM and a 1 GB database for free
   * [pagodabox.io](http://pagodabox.io/) — Small worker, web server, cache, and database for free
   * [cloudandheat.com](https://cloudandheat.com/) — 128 MB of RAM for free, includes support for custom domains for free
-  * [apicastor.com](https://apicastor.com/) — Convert spreadsheets into URL and monitor access
+  * [apicastor.com](https://www.apicastor.com/) — Convert spreadsheets into URL and monitor access
   * [formlets.com](https://formlets.com/) — Online forms, unlimited single page forms/month, 100 submissions/month, email notifications
   * [superfeedr.com](https://superfeedr.com/) — Real-time PubSubHubbub compliant feeds, export, analytics. Free with less customization
   * [diffd.com](http://diffd.com/) — Compare website versions with highlighted changes before you deploy, free for 100 pages/month
@@ -344,7 +344,7 @@ Table of Contents
 ## Web Hosting
 
   * [closeheat.com](http://closeheat.com/) — Development Environment in the Cloud for Static Websites with Free Hosting and GitHub integration. 1 free website with custom domain support
-  * [simplybuilt.com](https://simplybuilt.com/) — SimplyBuilt offers free website building and hosting for {[Open Source projects](http://www.simplybuilt.com/explore/free-websites-for-open-source-projects)}. Simple alternative to GitHub Pages
+  * [simplybuilt.com](https://www.simplybuilt.com/) — SimplyBuilt offers free website building and hosting for {[Open Source projects](http://www.simplybuilt.com/explore/free-websites-for-open-source-projects)}. Simple alternative to GitHub Pages
   * [devport.co](http://devport.co/) — Turn GitHub projects, apps, and websites into a personal developer portfolio
   * [netlify.com](https://netlify.com/) — Builds, deploy and hosts static site or app, free for 100 MB data and 1 GB bandwidth
   * [divshot.com](https://divshot.com/) — Static web hosting for developers, free basic apps, 1 GB bandwidth, 100 MB storage, custom domains, subdomain SSL
@@ -398,7 +398,7 @@ Table of Contents
    * stun:global.stun.twilio.com:3478?transport=udp — Twilio STUN
    * [segment.com](https://segment.com/) — Hub to translate and route events to other third party services. 100 K events/month free
    * [ngrok.com](https://ngrok.com/) — Expose locally running servers over a tunnel to a public URL
-   * [cloudamqp.com](https://cloudamqp.com/) — RabbitMQ as a Service. Little Lemur plan: max 1 million messages/month, max 20 concurrent connections, max 100 queues, max 10,000 queued messages, multiple nodes in differen AZ's
+   * [cloudamqp.com](https://www.cloudamqp.com/) — RabbitMQ as a Service. Little Lemur plan: max 1 million messages/month, max 20 concurrent connections, max 100 queues, max 10,000 queued messages, multiple nodes in differen AZ's
 
 
 ## Issue Tracking and Project Management

--- a/readme2.md
+++ b/readme2.md
@@ -1,0 +1,564 @@
+# free-for-dev
+Developers and Open Source authors now have a massive amount of services offering free tiers, but it can be hard to find them all in order to make informed decisions.
+
+This is list of software (SaaS, PaaS, IaaS, etc.) and other offerings that have free tiers for developers.
+
+The scope of this particular list is limited to things infrastructure developers (System Administrator, DevOps Practitioners, etc.) are likely to find useful. We love all the free services out there, but it would be good to keep it on topic. It's a bit of a grey line at times so this is a bit opinionated; do not be offended if I do not accept your contribution.
+
+You can help by sending Pull Requests to add more services. Once I have a good set of links in this README file, I'll look into a better layout for the information and links (help with that is appreciated too).
+
+*NOTE:* This list is only for as-a-Service offerings, not for self hosted software.
+
+Table of Contents
+=================
+
+   * [Source Code Repos](#source-code-repos)
+   * [Tools for Teams and Collaboration](#tools-for-teams-and-collaboration)
+   * [Code Quality](#code-quality)
+   * [Code Search and Browsing](#code-search-and-browsing)
+   * [CI / CD](#ci--cd)
+   * [Automated Browser Testing](#automated-browser-testing)
+   * [Security and PKI](#security-and-pki)
+   * [Management Systems](#management-system)
+   * [Log Management](#log-management)
+   * [Translation Management](#translation-management)
+   * [Monitoring](#monitoring)
+   * [Crash and Exception Handling](#crash-exception-handling)
+   * [Search](#search)
+   * [Email](#email)
+   * [CDN and Protection](#cdn-and-protection)
+   * [PaaS](#paas)
+   * [BaaS](#baas)
+   * [Web Hosting](#web-hosting)
+   * [DNS](#dns)
+   * [IaaS](#iaas)
+   * [DBaaS](#dbaas)
+   * [STUN, WebRTC, Web Socket Servers and Other Routers](#stun-webrtc-web-socket-servers-and-other-routers)
+   * [Issue Tracking and Project Management](#issue-tracking-and-project-management)
+   * [Storage and Media Processing](#storage-and-media-processing)
+   * [Design and UI](#design-and-ui)
+   * [Data Visualization on Maps](#data-visualization-on-maps)
+   * [Package Build System](#package-build-systems)
+   * [IDE and Code Editing](#ide-and-code-editing)
+   * [Analytics, Events and Statistics](#analytics-events-and-statistics)
+   * [International Mobile Number Verification API and SDK](#international-mobile-number-verification-api-and-sdk)
+   * [Payment / Billing Integration](#payment-billing-integration)
+   * [Other Packs](#other-packs)
+   * [Docker Related](#docker-related)
+   * [Alternate Container Hosting](#alternate-container-hosting)
+   * [Vagrant Related](#vagrant-related)
+   * [Vagrant Box Indexes](#vagrant-box-indexes)
+   * [Technology watch](#technology-watch)
+   * [Data Mining](#data-mining)
+   * [Other Lists](#other-lists)
+
+## Source Code Repos
+
+  * [bitbucket.org](https://bitbucket.org/) — Free unlimited public and private repos (Git and Mecurial) for up to 5 users
+  * [chiselapp.com](http://chiselapp.com/) — Unlimited public and private Fossil repositories
+  * [github.com](https://github.com/) — Free for an unlimited number of public repositories
+  * [about.gitlab.com](https://about.gitlab.com/) — Unlimited public and private Git repos with unlimited collaborators
+  * [hub.jazz.net](https://hub.jazz.net/) — Unlimited public repos, private repos free for up to 3 accounts
+  * [visualstudio.com](https://visualstudio.com/) — Free unlimited private repos (Git and TFS) for up to 5 users per team
+  * [assembla.com](https://assembla.com/) — Free repo hosting in a free plan
+  * [fogcreek.com](http://fogcreek.com/kiln/) — Free unlimited public and private repos (hybrid of Git and Mecurial) for 2 users
+  * [plasticscm.com](https://plasticscm.com/) — Free for individuals, OSS and non-profits
+  * [cloud.google.com](https://cloud.google.com/tools/cloud-repositories/) — Free private Git repositories hosted on Google Cloud Platform. Supports syncing with existing GitHub and Bitbucket repos. Free Beta for up to 500 MB of storage
+
+## Tools for Teams and Collaboration
+
+  * [appear.in](http://appear.in/) — One click video conversations, for free
+  * [flowdock.com](https://flowdock.com/) — Chat and inbox, free for teams up to 5
+  * [slack.com](https://slack.com/) — Free for unlimited users with some feature limitations
+  * [hipchat.com](https://hipchat.com/) — Free for unlimited users with some feature limitations
+  * [gitter.im](https://gitter.im/) — Chat, for GitHub. Unlimited public & private rooms, free for teams of up to 25
+  * [google.com/hangouts](http://google.com/hangouts/) — One place for all your Conversations, for free, need a Google account
+  * [seafile.com](http://seafile.com/) — Private or cloud storage, file sharing, sync, discussions. Private version is full. Cloud version has just 1 GB
+  * [sameroom.io](https://sameroom.io/) — Free for unlimited users with some feature limitations
+  * [yammer.com](https://yammer.com/) — Private social network standalone or for MS Office 365. Free, just a bit less admin tools and users management features
+  * [helpmonks.com](https://helpmonks.com/) — Shared inbox for teams, free for Open Source and non-profit organizations
+  * [typetalk.in](http://typetalk.in/) — Share and discuss ideas with your team through instant messaging on the web or on your mobile
+  * [talky.io](https://talky.io/) — Free group video chat. Anonymous. Peer‑to‑peer. No plugins, signup, or payment required
+  * [sourcetalk.net](http://sourcetalk.net/) — Code discussion tool, free for open code talks
+  * [vipaar.com](http://vipaar.com/) — Help over video with augmented reality. Free without analytics, encryption, support
+  * [evernote.com](https://evernote.com/) — Tool for organizing information. Share your notes and work together with others
+  * [wunderlist.com](https://wunderlist.com/) — Share your lists and work collaboratively on projects with your colleagues, free on iPhone, iPad, Mac, Android, Windows and the web
+  * [doodle.com](http://doodle.com/) — The scheduling tool you'll actually use. Find a date for a meeting 2 times faster
+  * [sendtoinc.com](https://sendtoinc.com/) — Share links, notes, files and have discussions. Free for 3 and 100 MB
+  * [zoom.us](https://zoom.us/) — Secure Video and Web conferencing, add-ons available. Free limited to 40 min
+  * [ideascale.com](https://ideascale.com/) — Allow clients to submit ideas and vote, free for 25 members in 1 community
+  * [filehero.io](https://filehero.io/) — Make it easy to access your company's file storage from a corporate download page. Free for 5 concurrent downloads
+  * [wistia.com](http://wistia.com/) — Video hosting with viewer analytics, HD video delivery, and marketing tools to help understand your visitors, 25 videos and Wistia branded player
+  * [cnverg.com](https://cnverg.com/) — Real-time shared visual workspace, whiteboard, GitHub integration. Free 5 GB, 5 spaces and 5 collaborators, no GitHub repos
+
+
+## Code Quality
+
+  * [tachikoma.io](http://tachikoma.io/) — Dependency Update for Ruby, Node.js, Perl projects, free for Open Source
+  * [gemnasium.com](https://gemnasium.com/) — Dependency Update for Ruby, Node.js projects, free for Open Source
+  * [deppbot.com](https://deppbot.com/) — Automated Dependency Updates for Ruby projects, free for Open Source
+  * [landscape.io](https://landscape.io/) — Code Quality for Python projects, free for Open Source
+  * [codeclimate.com](https://codeclimate.com/) — Automated code review, free for Open Source
+  * [houndci.com](https://houndci.com/) — Comments on GitHub commits about code quality, free for Open Source
+  * [coveralls.io](https://coveralls.io/) — Display test coverage reports, free for Open Source
+  * [scrutinizer-ci.com](https://scrutinizer-ci.com/) — Continuous inspection platform, free for Open Source
+  * [codecov.io](https://codecov.io/) — Code coverage tool (SaaS), free for Open Source
+  * [insight.sensiolabs.com](https://insight.sensiolabs.com/) — Code Quality for PHP/Symfony projects, free for Open Source
+  * [codacy.com](https://codacy.com/) — Automated code reviews for PHP, Python, JavaScript, Scala and CSS, free for Open Source
+  * [pullreview.com](https://pullreview.com/) — Automated Code Review for Ruby in GitHub, Bitbucket and GitLab, free for Open Source
+  * [gocover.io](http://gocover.io/) — Code coverage for any [Go](http://golang.org/) package
+  * [inch-ci.org](http://inch-ci.org/) — Documentation badges for Ruby, JS and Elixir
+  * [scan.coverity.com](https://scan.coverity.com/) — Static code analysis for Java, C/C++, C# and JavaScript, free for Open Source
+  * [webceo.com](http://webceo.com/) — SEO tools but with also code verifications and different type of advices
+  * [zoompf.com](https://zoompf.com/) — Fix the performance of your web sites, detailed analysis
+  * [websitetest.com](http://websitetest.com/) — Yotta's tool to optimize web sites, free limited version online
+  * [gtmetrix.com](https://gtmetrix.com/) — Reports and thorough recommendations to optimize websites
+  * [browserling.com](http://browserling.com/) — Live interactive cross-browser testing, free only 3 min. sessions with MS IE 9 under Vista at 1024 x 768 resolution
+  * [loadfocus.com](https://loadfocus.com/) — Load and speed tests for websites, mobile apps and APIs, monitoring,... Free 5 tests/month, 120 clients/test, 1 monitor, 1 location,...
+  * [versioneye.com](https://versioneye.com/) — Monitor your source code and notify about outdated dependencies. Free for open source and public repos
+  * [beanstalkapp.com](http://beanstalkapp.com/) — A complete workflow to write, review & deploy code), free account for 1 user and 1 repository, with 100 MB of storage
+
+## Code Search and Browsing
+  * [sourcegraph.com](https://sourcegraph.com/) — Java, Go, Python, Node.js, etc., code search/cross-references, free for Open Source
+  * [searchcode.com](https://searchcode.com/) — Comprehensive text-based code search, free for Open Source
+
+## CI / CD
+
+  * [codeship.com](https://codeship.com/) — 100 private builds/month, 5 private projects, unlimited for Open Source
+  * [circleci.com](https://circleci.com/) — Free for one concurrent build
+  * [travis-ci.org](https://travis-ci.org/) — Free for public GitHub repositories
+  * [wercker.com](http://wercker.com/) — Free for public and private repositories
+  * [drone.io](https://drone.io/) — CI platform that includes browser testing, free for Open Source
+  * [semaphoreci.com](https://semaphoreci.com/) — 100 private builds/month, unlimited for Open Source
+  * [shippable.com](http://shippable.com/) — Free for 1 build container, private and public repos, unlimited builds
+  * [snap-ci.com](https://snap-ci.com/) — Free for public repositories, 1 build at the time
+  * [appveyor.com](http://appveyor.com/) — CD service for Windows, free for Open Source
+  * [github.com](https://github.com/ligurio/Continuous-Integration-services) — Comparison of Continuous Integration services
+  * [ftploy.com](http://ftploy.com/) — 1 project with unlimited deployments
+  * [deployhq.com](https://deployhq.com/) — 1 project with 10 daily deployments
+  * [hub.jazz.net](https://hub.jazz.net/) — 60 minutes of free build time/month
+  * [styleci.io](https://styleci.io/) — Public GitHub repositories only
+  * [deploybot.com](http://deploybot.com/) — Free for 1 repository, private or public. Supports any service you can throw at it
+  * [bitrise.io](https://bitrise.io/) — iOS CI/CD with 200 free builds/month
+  * [saucelabs.com](https://saucelabs.com/) — CI with scalable testing for mobile and web apps, free for Open Source
+
+## Automated Browser Testing
+  * [gridlastic.com](https://gridlastic.com) — Selenium Grid testing with free plan up to 4 simultaneous selenium nodes/10 grid starts/4,000 test minutes per month
+  * [browserstack.com](https://browserstack.com/) — Manual and automated browser testing, free for Open Source
+
+## Security and PKI
+
+  * [crypteron.com](https://crypteron.com/) — Cloud-first, developer-friendly security platform prevents data breaches in .NET and Java applications
+  * [vaddy.net](http://vaddy.net/) — Continuous web security testing with continuous integration (CI) tools. 3 domains, 10 scans history for free
+  * [letsencrypt.org](https://letsencrypt.org/) — Free SSL Certificate Authority with certs trusted by all major browsers
+  * [globalsign.com](https://globalsign.com/en/ssl/ssl-open-source/) — Free SSL certificates for Open Source
+  * [startssl.com](https://startssl.com/) — Free SSL certs
+  * [soclall.com](http://soclall.com/) — Free up to 1,000 users login, post, share through top 20+ social networks
+  * [stormpath.com](https://stormpath.com/) — Free user management, authentication, social login, and SSO
+  * [auth0.com](https://auth0.com/) — Hosted free for development SSO
+  * [getclef.com](https://getclef.com/) — New take on auth unlimited free tier for anyone not using premium features
+  * [ringcaptcha.com](https://ringcaptcha.com/) — Tools to use phone number as id, available for free
+  * [ssllabs.com](https://ssllabs.com/ssltest/) — Very deep analysis of the configuration of any SSL web server
+  * [qualys.com](https://qualys.com/forms/freescan/owasp/) — Find web app vulnerabilities, audit for OWASP Risks
+  * [alienvault.com](https://alienvault.com/open-threat-exchange/threatfinder) — Uncovers compromised systems in your network
+  * [duosecurity.com](https://duosecurity.com/) — Two-factor authentication (2FA) for website or app. Free 10 users, all authentication methods, unlimited, integrations, hardware tokens
+  * [tinfoilsecurity.com](https://tinfoilsecurity.com/) — Automated vulnerability scanning. Free plan = weekly XSS scans
+  * [acunetix.com](http://acunetix.com/free-network-security-scanner/) — Free vulnerability and network scanning for 3 targets
+  * [ponycheckup.com](https://ponycheckup.com/) — An automated security checkup tool for Django websites
+  * [foxpass.com](https://foxpass.com/) — Hosted LDAP and RADIUS. Easy per-user logins to servers, VPNs, and wireless networks. Free for 10 users
+  * [opswatgears.com](https://opswatgears.com/) — Security Monitoring of computers, devices, applications, configurations,... Free 25 users and 30 days history
+  * [bitninja.io](https://bitninja.io/) — Botnet protection through a blacklist, free plan only reports limited information on each attack
+  * [onelogin.com](https://onelogin.com/) — Identity as a Service (IDaaS), Single Sign-On Identity Provider, Cloud SSO IdP, 3 company apps and 5 personal apps, unlimited users
+  * [logintc.com](https://logintc.com/) — Two-factor authentication (2FA) by push notifications, free for 10 users, VPN, Websites and SSH
+
+## Management System
+
+  * [bitnami.com](https://bitnami.com/) — Deploy prepared apps on IaaS. Management of 1 AWS micro instance free
+  * [visualops.io](http://visualops.io/) — 3,600 instance hours/month free
+
+## Log Management
+
+  * [papertrailapp.com](https://papertrailapp.com/) — 48 hours search, 7 days archive, 100 MB/month
+  * [logentries.com](https://logentries.com/) — Free up to 5 GB/month with 7 days retention
+  * [loggly.com](https://loggly.com/) — Free for a single user, see the ```lite``` option
+  * [sematext.com](http://sematext.com/logsene) — Free for 1 million logs, unlimited retention
+  * [sumologic.com](https://sumologic.com/) — Free up to 500 MB/day, 7 days retention
+
+## Translation Management
+
+  * [lingohub.com](https://lingohub.com/) — Free up to 3 users, always free for Open Source
+  * [getlocalization.com](https://getlocalization.com/) — Free for public projects
+  * [webtranslateit.com](http://webtranslateit.com/) — Free up to 500 strings
+  * [transifex.com](http://transifex.com/) — Free for Open Source
+  * [oneskyapp.com](http://oneskyapp.com/) — Limited free edition for up to 5 users, free for Open Source
+  * [crowdin.com](https://crowdin.com/) — Unlimited projects, unlimited strings and collaborators for Open Source
+
+## Monitoring
+
+  * [opbeat.com](https://opbeat.com/) — Application performance, errors and releases. Free with 24 hours data retention
+  * [checkmy.ws](https://checkmy.ws/en/solutions/free-forever-for-foss/) — Free 15 days full demo and 3 websites, forever free for Open Source
+  * [appneta.com](http://appneta.com/) — Free with 1 hour data retention
+  * [thousandeyes.com](https://thousandeyes.com/) — Network and user experience monitoring. 3 locations, plus 20 data feeds of major web services free
+  * [datadoghq.com](https://datadoghq.com/) — Free for up to 5 nodes
+  * [stackdriver.com](http://stackdriver.com/) — Free monitoring up to 10 servers/hosted services
+  * [keymetrics.io](https://keymetrics.io/) — Free for 2 servers with 7 days data retention
+  * [newrelic.com](http://newrelic.com/) — Free with 24 hours data retention
+  * [nodequery.com](https://nodequery.com/) — Free basic server monitor up to 10 servers
+  * [pingdom.com](https://pingdom.com/free/) — Free for 1 site
+  * [watchsumo.com](http://watchsumo.com/) — Free website monitoring, 50 Http(s), Ping or keywords, every 5+ minutes
+  * [opsgenie.com](https://opsgenie.com/) — Alert management with mobile push. 600 free alerts/month for 2 users
+  * [runscope.com](https://runscope.com/) — Monitor and log API usage. Single user 25,000 requests/month free
+  * [circonus.com](http://circonus.com/) — Free for 20 metrics
+  * [uptimerobot.com](https://uptimerobot.com/) — Website monitoring, 50 monitors free
+  * [statuscake.com](https://statuscake.com/) — Website monitoring, unlimited tests free with limitations
+  * [boundary.com](http://boundary.com/) — Free 1 second resolution for up to 10 servers
+  * [ghostinspector.com](https://ghostinspector.com/) — Free website and web application monitoring. Single user, 100 test runs/month
+  * [java-monitor.com](http://java-monitor.com/) — Free monitoring of JVM's and uptime
+  * [sematext.com](http://sematext.com/) — Free for 24 hours metrics, unlimited number of servers, 10 custom metrics, 500 K custom metrics data points, unlimited dashboards, users, etc
+  * [sealion.com](https://sealion.com/) — Free up to 2 servers, 3 days data retention, graphs and raw command output history (`top`, `ps`, `ifconfig`, `netstat`, `iostat`, `free`, custom, etc.)
+  * [stathat.com](https://stathat.com/) — Get started with ten stats for free, no expiration
+  * [skylight.io](https://skylight.io/) — Free for first 100 K requests
+  * [appdynamics.com](https://appdynamics.com/) — Free for 24 hours metrics, application performance management agents limited to one Java, one .NET, one PHP, and one Node.js
+  * [deadmanssnitch.com](https://deadmanssnitch.com/) — Monitoring for cron jobs. 1 free snitch (monitor), more if you refer others to sign up
+  * [librato.com](https://librato.com/) — Free up to 100 metrics at 60 sec. resolution
+  * [freeboard.io](https://freeboard.io/) — Free for public projects. Dashboards for your Internet of Things projects
+  * [loader.io](https://loader.io/) — Free load testing tools with limitations
+  * [probeapi.com](http://probeapi.com/) — Performance Monitoring API, checks Ping, DNS, etc
+  * [blackfire.io](https://blackfire.io/) — Blackfire is the SaaS-delivered Application Performance Solution. Free Hacker plan
+  * [apimetrics.io](http://apimetrics.io/) — Automated API Performance Monitoring, Testing and Analytics. Free Plan, manually make API calls and Run from their West Coast servers
+  * [opsdash.com](https://opsdash.com/) — Self-hoster server, clusters and services monitoring, free for 5 servers and 5 services
+
+## Crash and Exception Handling
+
+  * [rollbar.com](https://rollbar.com/) — Exception and error monitoring, free plan with 5,000 errors/month, unlimited users, 30 days retention
+  * [bugsnag.com](https://bugsnag.com/) — Free for up to 2,000 errors/month after the initial trial
+  * [airbrake.io](https://airbrake.io/) — Automatically groups, organizes and notifies you about your application errors. Free plan with 7,200 errors/day, 1 user, 1 project, 2 days retention
+  * [getsentry.com](http://getsentry.com/) — Sentry tracks app exceptions in realtime, has a small free plan. Free, unrestricted use if self-hosted
+
+## Search
+
+  * [algolia.com](https://algolia.com/) — Hosted search-as-you-type (instant). Free hacker plan up to 10,000 documents and 100,000 operations. Bigger free plans available for community/Open Source projects
+  * [swiftype.com](https://swiftype.com/) — Hosted search solution (API and crawler). Free for a single search engine with up to 1,000 documents. Free upgrade to Premium level for Open Source
+  * [bonsai.io](https://bonsai.io/) — Free 1 GB memory and 1 GB storage
+  * [searchly.com](http://searchly.com/) — Free 2 indices and 5 MB storage
+  * [facetflow.com](https://facetflow.com/) — Hosted Elasticsearch for Microsoft Azure. Free 5,000 docs / 500 MB
+  * [indexisto.com](http://indexisto.com/) — Site search reinvented. Free 10,000,000 document index limit with advertisement block
+
+## Email
+
+  * [sparkpost.com](http://sparkpost.com/) — First 10,000 emails/month are free
+  * [mailgun.com](http://mailgun.com/) — First 10,000 emails/month are free
+  * [mailchimp.com](http://mailchimp.com/) — 2,000 subscribers and 12,000 emails/month are free
+  * [sendloop.com](https://sendloop.com/) — 2,000 subscribers and 10,000 emails/month are free
+  * [sendgrid.com](http://sendgrid.com/) — 400 emails/day for free and 25,000 free transactional emails/month for emails sent from a Google compute instance or Microsoft Azure App Service
+  * [mandrill.com](http://mandrill.com/) — First 2,000 emails are free
+  * [phplist.com](https://phplist.com/) — Hosted version allow 300 emails/month for free
+  * [mailjet.com](https://mailjet.com/) — 6,000 emails/month for free
+  * [sendinblue.com](https://sendinblue.com/) — 9,000 emails/month for free
+  * [mailtrap.io](https://mailtrap.io/) — Fake SMTP server for development, free plan with 1 inbox, 50 messages, no team member, 2 emails/sec, no forward rules
+  * [mailstache.io](https://mailstache.io/) — 4 mailboxes with 1 GB each for up to 2 custom domains
+  * [postmarkapp.com](https://postmarkapp.com/) — First 25,000 emails are free
+  * [zoho.com](https://zoho.com/mail/) — Free email management and collaboration for up to 10 users
+  * [domain.yandex.com](https://domain.yandex.com/domains_add/) — Free email and DNS hosting for up to 1,000 users
+  * [moosend.com](http://moosend.com/) — Mailing list management service. Free account for 6 months for startups
+  * [debugmail.io](https://debugmail.io/) — Easy to use testing mail server for developers
+  * [mailboxlayer.com](https://mailboxlayer.com/) — Email validation and verification JSON API for developers. 1,000 free API requests/month
+  * [mailcatcher.me](http://mailcatcher.me/) — Catches mail and serves it through a web interface
+  * [yopmail.fr](http://yopmail.fr/en/) — Disposable email addresses
+  * [kickbox.io](http://kickbox.io/) — Verify 100 emails free, real time API available
+
+## CDN and Protection
+
+  * [cloudflare.com](http://cloudflare.com/) — Basic service is free, good for a blog, Cloudflare also offers a free SSL certificate service
+  * [bootstrapcdn.com](http://bootstrapcdn.com/) — CDN for bootstrap, bootswatch and font awesome
+  * [surge.sh](https://surge.sh/) — Zero-bullshit, single–command, bring your own source control web publishing CDN
+  * [cdnjs.com](https://cdnjs.com/) — CDN for JavaScript libraries, CSS libraries, SWF, images, etc
+  * [jsdelivr.com](http://jsdelivr.com/) — Super-fast CDN of OSS (JS, CSS, fonts) for developers and webmasters, accepts PRs to add more
+  * [developers.google.com](https://developers.google.com/speed/libraries/) — The Google Hosted Libraries is a content distribution network for the most popular, Open Source JavaScript libraries
+  * [asp.net](https://asp.net/ajax/cdn/) — The Microsoft Ajax Content Delivery Network (CDN) hosts popular third party JavaScript libraries such as jQuery and enables you to easily add them to your Web application
+  * [toranproxy.com](https://toranproxy.com/) — Proxy for Packagist and GitHub. Never fail CD. Free for personal use, 1 developer, no support
+  * [rawgit.com](http://rawgit.com/) — Free limited traffic, serves raw files directly from GitHub with proper Content-Type headers
+  * [incapsula.com](https://incapsula.com/) — Free CDN and DDoS protection
+  * [fastly.com](https://fastly.com/) — Free CDN, all features until $50/month is reached, enough for most, then pay or suspended
+  * [ddos-protection.io](http://ddos-protection.io/) — Free DDoS protection with unlimited websites
+  * [section.io](https://section.io/) — A simple way to spin up and manage a complete Varnish Cache solution. Supposedly free forever for one site
+  * [netdepot.com](https://netdepot.com/cdn/) — First 100 GB free/month
+
+## PaaS
+  * [restlet.com](http://restlet.com/products/apispark/) — APISpark enables any API, application or data owner to become an API provider in minutes via an intuitive browser interface
+  * [cloud.google.com](https://cloud.google.com/appengine/) — Google App Engine gives 28 instance hours/day free, 1 GB NoSQL Database and more
+  * [engineyard.com](https://engineyard.com/) — Engine Yard provides 500 free hours
+  * [azure.microsoft.com](http://azure.microsoft.com/) — MS Azure gives $200 worth of free usage for a trial
+  * [appharbor.com](https://appharbor.com/) — A .Net PaaS that provides 1 free worker
+  * [shellycloud.com](https://shellycloud.com/) — Platform for hosting Ruby and Ruby on Rails apps. Shelly Cloud gives €20 free credit
+  * [heroku.com](https://heroku.com/) — Host your apps in the cloud, free for single process apps
+  * [firebase.com](https://firebase.com/) — Build realtime apps, free plan has 100 max. connections, 10 GB data transfer, 1 GB data storage, 1 GB hosting storage and 100 GB hosting transfer
+  * [bluemix.net](https://bluemix.net/) — IBM PaaS with a monthly free allowance
+  * [openshift.com](https://openshift.com/) — Red Hat PaaS, free tier provides three small gears each with 512 MB memory and 1 GB storage. {[Browse one-click deployments](https://hub.openshift.com/)}
+  * [algorithmia.com](https://algorithmia.com/) — Host and Use algorithms for free with 10,000 credits (seconds of on-demand execution time) free. Now with CLI support
+  * [bigml.com](https://bigml.com/) — Hosted machine learning algorithms. Unlimited free tasks for development, limit of 16 MB data/task
+  * [activestate.com](https://activestate.com/stackato/) — Enterprise-hardened Cloud Foundry PaaS from ActiveState, for private, public and hybrid cloud, free up to 20 GB
+  * [outsystems.com](http://outsystems.com/) — Enterprise web development PaaS for on-premise or cloud, free "personal environment" offering allows for unlimited code and up to 1 GB database
+  * [platform.telerik.com](https://platform.telerik.com/) — Build and deploy mobile applications using JavaScript. Free plan has 100 MB data storage, 1 GB file storage, 5 GB bandwidth, 1 million push notifications for BaaS offering, 100 active devices for analytics
+  * [scn.sap.com](http://scn.sap.com/docs/DOC-56411) — The in-memory Platform-as-a-Service offering from SAP. Free developer accounts come with 1 GB structured, 1 GB unstructured, 1 GB of Git data and allow you to run HTML5, Java and HANA XS apps
+  * [mendix.com](https://mendix.com/) — Rapid Application Development for Enterprises, unlimited number of free sandbox environments supporting 10 users, 100 MB of files and 100 MB database storage each
+  * [pythonanywhere.com](https://pythonanywhere.com/) — Cloud Python app hosting. Beginner account is free, 1 Python web application at your-username.pythonanywhere.com domain, 512 MB private file storage, one MySQL database
+  * [configure.it](http://configure.it/) — Mobile app development platform, free for 2 projects, limited features but no resource limits
+  * [stamplay.com](https://stamplay.com/) — 50 K API calls, 100 GB data transfer, and 1 GB storage for free
+  * [qtcloudservices.com](http://qtcloudservices.com/products/managed-runtime/) — Managed platform with micro runtime instance and database for free
+  * [elastx.com](http://elastx.com/start/easypaas/) — Free tier with up to 4 cloudlets, must be renewed every year
+  * [viaduct.io](https://viaduct.io/) — 350 MB of RAM and a 1 GB database for free
+  * [pagodabox.io](http://pagodabox.io/) — Small worker, web server, cache, and database for free
+  * [cloudandheat.com](https://cloudandheat.com/) — 128 MB of RAM for free, includes support for custom domains for free
+  * [apicastor.com](https://apicastor.com/) — Convert spreadsheets into URL and monitor access
+  * [formlets.com](https://formlets.com/) — Online forms, unlimited single page forms/month, 100 submissions/month, email notifications
+  * [superfeedr.com](https://superfeedr.com/) — Real-time PubSubHubbub compliant feeds, export, analytics. Free with less customization
+  * [diffd.com](http://diffd.com/) — Compare website versions with highlighted changes before you deploy, free for 100 pages/month
+
+## BaaS
+
+  * [apigee.com](http://apigee.com/docs/api-baas) — Unlimited trial includes NoSQL data store with 25 GB of storage, user and permission management, geolocation, 10,000,000 push notifications/month, remote configuration, beta and A/B split testing, APM, fully API driven. Accessible and manageable via UI, SDK, and API
+  * [appacitive.com](http://appacitive.com/) — Mobile backend, free for the first 3 months with 100 K API calls, push notifications
+  * [bip.io](https://bip.io/) — A web-automation platform for easily connecting web services. Fully open GPLv3 to power the backend of your Open Source project. Commercial OEM License available
+  * [blockspring.com](https://blockspring.com/) — Cloud functions. Free for 5 million runs/month
+  * [contentful.com](https://contentful.com/) — Content as a Service. Content management and delivery APIs in the cloud. 3 users, 3 spaces (repositories) and 1,000,000 API requests/month for free
+  * [kinvey.com](http://kinvey.com/) — Mobile backend, starter plan has unlimited requests/second, with 2 GB of data storage, as well as push notifications for up 5,000,000 unique recipients. Enterprise application support
+  * [konacloud.io](http://konacloud.io/) — Web and Mobile Backend as a Service, with 5 GB free account
+  * [layer.com](https://layer.com/) — The full-stack building block for communications
+  * [parse.com](https://parse.com/) — Mobile backends, free plan has 30 requests/sec, with 20 GB of file and database storage, as well as push notifications for up to 1,000,000 unique recipients
+  * [quickblox.com](http://quickblox.com/) — A communication backend for instant messaging, video and voice calling, and push notifications
+  * [pushbots.com](https://pushbots.com/) — Push notification service. Free for up to 1,500,000 push/month
+  * [dreamfactory.com](http://dreamfactory.com/) — DreamFactory is an Open Source backend platform that provides all of the RESTful services you need to build fantastic mobile and web applications
+  * [mashape.com](https://mashape.com/) — API Marketplace And Powerful Tools For Private And Public APIs. With the free tier, some features are limited such as monitoring, alerting and support
+  * [onesignal.com](https://onesignal.com/) — Unlimited free push notifications
+  * [getstream.io](https://getstream.io/) — Build scalable news feeds and activity streams in a few hours instead of weeks, free for 3 million feed updates/month
+  * [tyk.io](https://tyk.io/) — API management with authentication, quotas, monitoring, and analytics. Free cloud offering
+  * [iron.io](http://iron.io/) — Async task processing (like AWS Lambda) with free tier and 1 month free trial
+  * [stackhut.com](http://stackhut.com/) — Async task processing (like AWS Lambda). 10 free private services and unlimited free public services
+  * [pubnub.com](https://pubnub.com/) — Free push notifications for up to 1,000,000 messages/month and 100 active daily devices
+  * [webtask.io](https://webtask.io/) — Run code with an HTTP call. No provisioning. No deployment
+  * [zapier.com](https://zapier.com/) — Connect the apps you use, to automate tasks. 5 zaps, every 15 min. and 100 tasks/month
+  * [stackstorm.com](https://stackstorm.com/) — Event-driven automation for apps, services and workflows, free without flow, access control, LDAP,...
+  * [simperium.com](https://simperium.com/) — Move data everywhere instantly and automatically, multi-platform, unlimited sending and storage of structured data, max. 2,500 users/month
+
+## Web Hosting
+
+  * [closeheat.com](http://closeheat.com/) — Development Environment in the Cloud for Static Websites with Free Hosting and GitHub integration. 1 free website with custom domain support
+  * [simplybuilt.com](https://simplybuilt.com/) — SimplyBuilt offers free website building and hosting for {[Open Source projects](http://www.simplybuilt.com/explore/free-websites-for-open-source-projects)}. Simple alternative to GitHub Pages
+  * [devport.co](http://devport.co/) — Turn GitHub projects, apps, and websites into a personal developer portfolio
+  * [netlify.com](https://netlify.com/) — Builds, deploy and hosts static site or app, free for 100 MB data and 1 GB bandwidth
+  * [divshot.com](https://divshot.com/) — Static web hosting for developers, free basic apps, 1 GB bandwidth, 100 MB storage, custom domains, subdomain SSL
+  * [pantheon.io](https://pantheon.io/) — Drupal and WordPress hosting, automated DevOps, and scalable infrastructure. Free for developers and agencies
+  * [acquia.com](https://acquia.com/) — Hosting for Drupal sites. Free tier for developers. Free development tools (such as Acquia Dev Desktop) also available
+  * [bitballoon.com](https://bitballoon.com/) — BitBalloon offers hosting for static sites and apps. Free on a subdomain
+  * [readthedocs.org](https://readthedocs.org/) — Free documentation hosting with versioning, PDF generation and more
+  * [bubble.is](https://bubble.is/) — Visual programming to build web and mobile apps without code, free 100 visitors/month, 2 apps
+
+## DNS
+  * [freedns.afraid.org](https://freedns.afraid.org/) — Free DNS hosting
+  * [dns.he.net](https://dns.he.net/) — Free DNS hosting service with Dynamic DNS Support
+  * [luadns.com](http://luadns.com/) — Free DNS hosting, 3 domains, all features with reasonable limits
+  * [domain.yandex.com](https://domain.yandex.com/domains_add/) — Free email and DNS hosting for up to 1,000 users
+  * [cloudns.net](https://cloudns.net/) — Free DNS hosting up to 3 domains with unlimited records
+
+## IaaS
+
+  * [aws.amazon.com](http://aws.amazon.com/free/) — AWS Free Tier, free for 12 months
+  * [exoscale.ch](https://exoscale.ch/) — Free resources for Open Source
+  * [developer.rackspace.com](https://developer.rackspace.com/) — Rackspace Cloud gives $50/month for 12 months
+  * [cloud.google.com/compute](https://cloud.google.com/compute/) — Google Compute Engine gives $300 over 60 days
+  * [cloud.google.com/engine](https://cloud.google.com/container-engine/) — Google Container Engine for run Docker containers (Alpha). Pricing: same of Google Compute Engine
+  * [nsone.net](https://nsone.net/) — Data Driven DNS, automatic traffic management, 1 million free Queries
+  * [virtzone.net](http://virtzone.net/) — Free VPS. You must meet certain minor qualifications
+
+## DBaaS
+
+   * [cloudant.com](https://cloudant.com/) — Hosted database from IBM, free if usage is below $50/month
+   * [orchestrate.io](https://orchestrate.io/) — 1 application free
+   * [redislabs.com](https://redislabs.com/redis-cloud) — Redis as a Service, 30 MB and 30 concurrent connections free
+   * [backand.com](https://backand.com/) — Back-end as a service for AngularJS
+   * [zenginehq.com](http://zenginehq.com/) — Build business workflow apps in minutes, free for single users
+   * [parsehub.com](https://parsehub.com/) — Extract data from dynamic sites, turn dynamic websites into APIs, 5 projects free
+   * [import.io](https://import.io/) — Easily turn websites into APIs, completely free for life
+   * [kimonolabs.com](https://kimonolabs.com/) — Turn websites into structured APIs from your browser in seconds, free for public APIs, up to 20 million pages fetch/month. Supports scheduling, JSON, CSV, post-auth,...
+   * [redsmin.com](https://redsmin.com/) — Online real-time monitoring and administration service for Redis, 1 Redis instance free
+   * [graphstory.com](http://graphstory.com/) — GraphStory offers Neo4j (a Graph Database) as a service
+   * [elephantsql.com](http://elephantsql.com/) — PostgreSQL as a service, 20 MB free
+   * [graphenedb.com](http://graphenedb.com/) — Neo4j as a service, up to 1,000 nodes and 10,000 relations free
+   * [mongolab.com](https://mongolab.com/) — MongoDB as a service, 500 MB free
+   * [scalingo.com](https://scalingo.com/) — Primarily a PaaS but offers a 512 MB free tier of MySQL, PostgreSQL, or MongoDB
+   * [skyvia.com](https://skyvia.com/) — Cloud Data Platform, offers free tier and all plans are completely free while in beta
+   * [airtable.com](https://airtable.com/) — Looks like a spreadsheet, but it's a relational database, unlimited bases, 1,200/base and 1,000 API request/month
+   * [iriscouch.com](https://iriscouch.com/) — CouchDB as a service. Free for developing, prototyping, etc
+
+## STUN, WebRTC, Web Socket Servers and Other Routers
+
+   * [pusher.com](https://pusher.com/) — Hosted Web Sockets broker. Free for up to 20 simultaneous connections and 100 K messages/day
+   * stun:stun.l.google.com:19302 — Google STUN
+   * stun:global.stun.twilio.com:3478?transport=udp — Twilio STUN
+   * [segment.com](https://segment.com/) — Hub to translate and route events to other third party services. 100 K events/month free
+   * [ngrok.com](https://ngrok.com/) — Expose locally running servers over a tunnel to a public URL
+   * [cloudamqp.com](https://cloudamqp.com/) — RabbitMQ as a Service. Little Lemur plan: max 1 million messages/month, max 20 concurrent connections, max 100 queues, max 10,000 queued messages, multiple nodes in differen AZ's
+
+
+## Issue Tracking and Project Management
+
+   * [bitrix24.com](https://bitrix24.com/) — Free intranet and project management tool
+   * [pivotaltracker.com](https://pivotaltracker.com/community/public-projects) — Pivotal Tracker, free for public projects
+   * [atlassian.com](https://atlassian.com/opensource/overview) — Free Jira etc for Open Source
+   * [kanbantool.com](http://kanbantool.com/) — Kanban board based project management. Free (paid plans with more options)
+   * [kanbanflow.com](https://kanbanflow.com/) — Board based project management. Free (premium version with more options)
+   * [kanbanery.com](https://kanbanery.com/) — Board based project management. Free for 2 users (premium tiers with more options)
+   * [zenhub.io](https://zenhub.io/) — The only project management solution inside GitHub. Free for public repos, OSS, and non-profits
+   * [trello.com](https://trello.com/) — Board based project management. Free
+   * [producteev.com](https://producteev.com/) — Task management tool. Free (premium version with more options). Mobile applications available
+   * [fogcreek.com](http://fogcreek.com/fogbugz/) — Bug tracking and project management. Free for 2 users
+   * [waffle.io](https://waffle.io/) — Board based project management solution from your existing GitHub Issues, free for Open Source
+   * [huboard.com](https://huboard.com/) — Instant project management for your GitHub issues, free for Open Source
+   * [taiga.io](https://taiga.io/) — Project management platform for startups and agile developers, free for Open Source
+   * [jetbrains.com](https://jetbrains.com/youtrack/buy/open_source_incloud.jsp) — Free hosted YouTrack (InCloud) for FOSS projects, private projects {[free for 10 users](https://www.jetbrains.com/youtrack/buy/)}
+   * [github.com](https://github.com/) — In addition to its Git storage facility, GitHub offers basic issue tracking
+   * [asana.com](https://asana.com/) — Free for private project with collaborators
+   * [acunote.com](http://acunote.com/) — Free project management and SCRUM software for up to 5 team members
+   * [gliffy.com](http://gliffy.com/) — Online diagrams: flowchart, UML, wireframe,... Also plugins for Jira & Confluence. 5 diagrams and 2 MB free
+   * [cacoo.com](https://cacoo.com/) — Online diagrams in real time: flowchart, UML, network. Free max. 15 users/diagram, 25 sheets
+   * [draw.io](https://draw.io/) — Online diagrams stored locally, in Google Drive, OneDrive or Dropbox. Free for all features and storage levels
+   * [hub.jazz.net](https://hub.jazz.net/) — IBM Bluemix's project management services. Free for public projects, free for up to 3 users for private projects
+   * [leankit.com](http://leankit.com/) — Kanban board, that visualizes your workflow. Free up to 10 users
+   * [visualstudio.com](https://visualstudio.com/products/what-is-visual-studio-online-vs) — Unlimited free private code repositories; Tracks bugs, work items, feedback and more
+   * [testlio.com](https://testlio.com/) — Issue tracking, test management and beta testing platform. Free for private use
+   * [vivifyscrum.com](https://vivifyscrum.com/) — Free tool for Agile project management. Scrum Compatible
+   * [targetprocess.com](http://targetprocess.com/) — Visual project management, from Kanban and Scrum to almost any operational process. Free for unlimited users, up to 1,000 data entities {[more details](http://www.targetprocess.com/pricing/)}
+   * [overv.io](https://overv.io/) — Agile project management for teams who love GitHub
+   * [taskulu.com](https://taskulu.com/) — Role based project management. Free up to 5 users. Integration with GitHub/Trello/Dropbox/Google Drive
+   * [contriber.com](https://contriber.com/) — Customizable project management platform, free starter plan, 5 workspaces
+
+## Storage and Media Processing
+
+   * [aerofs.com](https://aerofs.com/) — P2P file syncing, free for up to 30 users
+   * [bintray.com](https://bintray.com/) — Binary File storage, free for Open Source. Includes SSL, CDN and a limited number of REST calls
+   * [cloudinary.com](http://cloudinary.com/) — Image upload, powerful manipulations, storage, and delivery for sites and apps, with libraries for Ruby, Python, Java, PHP, Objective-C and more. Perpetual free tier includes 7,500 images/month, 2 GB storage, 5 GB bandwidth
+   * [plot.ly](https://plot.ly/) — Graph and share your data. Free tier includes unlimited public files and 10 private files
+   * [transloadit.com](https://transloadit.com/) — Handles file uploads & encoding of video, audio, images, documents. Free for Open Source & other do-gooders. Commercial applications get the first GB free for test driving
+   * [podio.com](https://podio.com/) — You can use Podio with a team of up to five people and try out the features of the Basic Plan, except users management
+   * [shrinkray.io](https://shrinkray.io/) — Free image optimization of GitHub repos
+   * [imagefly.io](http://imagefly.io/) — Responsive images on-demand. CDN fronted image resizing, transcoding, and optimizing. 100 MB/month for free
+   * [kraken.io](https://kraken.io/) — Image optimization for website performance as a service, free plan up to 1 MB file size
+   * [placehold.it](https://placehold.it/) — A quick and simple image placeholder service
+   * [placekitten.com](https://placekitten.com/) — A quick and simple service for getting pictures of kittens for use as placeholders
+   * [placepenguin.com](http://placepenguin.com/) — A quick and simple service for placeholder images of penguins
+   * [embed.ly](http://embed.ly/) — Provides APIs for embeding media in a webpage, Responsive image scaling, extracting elements from a webpage. Free for up to 5,000 URLs/Month at 15 requests/sec
+   * [backhub.co](https://backhub.co/) — Backup and archive your GitHub repositories. Free for public repos
+   * [otixo.com](http://otixo.com/) — Encrypt, share, copy and move all your cloud storage files from one place. Basic plan provides unlimited files transfer with 250 MB max file size limit and allows 5 encrypted files
+   * [tinypng.com](https://tinypng.com/) — API to compress and resize PNG and JPEG images, offers 500 compressions for free each month
+   * [filestack.com](https://filestack.com/) — File picker, transform and deliver, free for 250 files, 500 transformations and 3 GB bandwith
+
+## Design and UI
+
+  * [pixlr.com](http://pixlr.com/) — Free online browser editor on the level of commercial ones
+  * [imagebin.ca](http://imagebin.ca/) — Pastebin for images
+  * [cloudconvert.com](https://cloudconvert.com/) — Convert anything to anything. 208 supported formats including videos to gif
+  * [resizeappicon.com](https://resizeappicon.com/) — A simple service to resize and manage your app icons
+  * [vectr.com](https://vectr.com/) — Free Design App For Web + Desktop
+  * [walkme.com](http://walkme.com/) — Enterprise Class Guidance and Engagement Platform, free plan 3 walk-thrus up to 5 steps/walk
+
+## Data Visualization on Maps
+
+   * [geocod.io](http://geocod.io/) — Geocoding via API or CSV Upload. 2,500 free queries/day
+   * [gogeo.io](http://gogeo.io/) — Maps and geospatial services with an easy to use API and support for big data
+   * [cartodb.com](https://cartodb.com/) — Create maps and geospatial APIs from your data and public data
+   * [giscloud.com](http://giscloud.com/) — Visualize, analyze and share geo data online
+   * [mapbox.com](https://mapbox.com/) — Maps, geospatial services, and SDKs for displaying map data
+
+## Package Build System
+
+   * [build.opensuse.org](https://build.opensuse.org/) — Package build service for multiple distros (SUSE, EL, Fedora, Debian etc.)
+   * [copr.fedoraproject.org](https://copr.fedoraproject.org/) — Mock-based RPM build service for Fedora and EL
+   * [help.launchpad.net](https://help.launchpad.net/Packaging) — Ubuntu and Debian build service
+
+## IDE and Code Editing
+
+   * [c9.io](https://c9.io/) — IDE in a browser. Incorporates an Ubuntu virtual machine and in-browser terminal access. Integrates with GitHub and BitBucket, but also adds SFTP and generic Git access
+   * [codeanywhere.com](https://codeanywhere.com/) — Full IDE in the browser and mobile apps. Access FTP, SFTP, Dropbox, Google Drive, GitHub, and BitBucket. Hosted virtual machines with terminal access. Collaboration features like share links, live editing, permissions, and version tracking
+   * [codenvy.com](https://codenvy.com/) — IDE and automated developer workspaces in a browser, collaborative, Git/SVN integration, build and run your app in customizable Docker-based runners (free tier includes: 4 GB RAM, always-on machines, ability to run multiple machines simultaneously), pre-integrated deploy to Google Apps
+   * [koding.com](https://koding.com/) — IDE in a browser. Full sudo access, VMs hosted on Amazon EC2, SSH Access, Real EC2 VM, no LXCs/hypervising, Custom sub-domains, Publicly accessible IP, Ubuntu 14.04, IDE/Terminal/Collaboration
+   * [nitrous.io](https://nitrous.io/) — Private Linux instance(s) with interactive collaboration, free for 2 hours/day. {[More Details](http://goo.gl/J1Zbsg)}
+   * [visualstudio.com](http://visualstudio.com/community) — Fully-featured IDE with thousands of extensions, cross-platform app development (Microsoft extensions available for download for iOS and Android), desktop, web and cloud development, multi-language support (C#, C++, JavaScript, Python, PHP and more)
+   * [code.visualstudio.com](http://code.visualstudio.com/) — Build and debug modern web and cloud applications. Code is free,open source and available on your favorite platform, Linux, Mac OSX and Windows
+   * [cloud.sagemath.com](https://cloud.sagemath.com/) — Collaborative mathematics-oriented IDE in a browser, with support for Python, LaTeX, IPython Notebooks, etc
+   * [wakatime.com](https://wakatime.com/) — Quantified self metrics about your coding activity, using text editor plugins, limited plan for free
+   * [apiary.io](https://apiary.io/) — Collaborative design API with instant API mock and generated documentation (Free for unlimited API blueprints and unlimited user with one admin account and hosted documentation)
+   * [mockable.io](https://mockable.io/) — Mockable is a simple configurable service to mock out RESTful API or SOAP web-services. This online service allows you to quickly define REST API or SOAP endpoints and have them return JSON or XML data
+   * [jetbrains.com](https://jetbrains.com/products.html) — Productivity tools, IDEs and deploy tools. Free license for students, teachers, Open Source, and user groups
+   * [readme.io](https://readme.io/) — Beautiful documentations made easy, free for Open Source
+   * [codio.com](https://codio.com/) — Codio is a cloud-based computer programming platform for universities, schools, and developer professionals
+   * [stackhive.com](http://stackhive.com/) — Cloud based IDE in browser that supports HTML5/CSS3/jQuery/Bootstrap
+   * [tadpoledb.com](http://tadpoledb.com/) — IDE in browser Database tool. Support Amazon RDS, Apache Hive, Apache Tajo, CUBRID, MariaDB, MySQL, Oracle, SQLite, MSSQL, PostgreSQL and MongoDB databases
+   * [sourcelair.com](https://sourcelair.com/) — In-browser IDE for Django, JavaScript, HTML5, Python, and more. Integrates with Git, Mercurial, GitHub, Heroku and more. Free forever for 1 private project
+   * [codepen.io](https://codepen.io/) — CodePen is a playground for the front end side of the web
+
+## Analytics, Events and Statistics
+
+   * [google.com/analytics](https://google.com/analytics/) — Google Analytics
+   * [heapanalytics.com](https://heapanalytics.com/) — Automatically captures every user action in iOS or web apps. Free for up to 5,000 visits/month
+   * [sematext.com](http://sematext.com/search-analytics) — Free for up to 50 K actions/month, 1 day data retention, unlimited dashboards, users, etc
+   * [usabilityhub.com](https://usabilityhub.com/) — Test designs and mockups on real people, track visitors. Free for one user, unlimited tests
+   * [gosquared.com](https://gosquared.com/) — Track up to 1,000 data points for free
+   * [mixpanel.com](https://mixpanel.com/) — Free 25,000 points or 200,000 with their badge on your site
+   * [amplitude.com](https://amplitude.com/) — 1 million monthly events, up to 2 apps
+   * [keen.io](https://keen.io/) — Custom Analytics for data collection, analysis and visualization. 50,000 events/month free
+   * [parse.com](https://parse.com/) — Unlimited free analytics
+   * [inspectlet.com](http://inspectlet.com/) — 100 sessions/month free for 1 website
+   * [mousestats.com](https://mousestats.com/) — 100 sessions/month free for 1 website
+   * [metrika.yandex.com](https://metrika.yandex.com/) — Unlimited free analytics
+   * [hotjar.com](https://hotjar.com/) — Per site: 2,000 pages views/day, 3 heatmaps, data stored for 3 months,...
+   * [imprace.com](http://imprace.com/) — Landing page analysis with suggestions to improve bounce rates. Free for 5 landing pages/domain
+   * [baremetrics.com](https://baremetrics.com/) — Analytics & Insights for stripe
+   * [optimizely.com](https://optimizely.com) — A/B Testing solution, free starter plan, 1 website, 1 iOS and 1 Android app
+   * [expensify.com](https://expensify.com/) — Expense reporting, free personal reporting approval workflow
+
+## International Mobile Number Verification API and SDK
+  * [cognalys.com](https://cognalys.com/) — Freemium mobile number verification through an innovative and reliable method than using SMS gateway. Free accounts will have 70 tries and 50 verifications/day. {[Signup](https://www.cognalys.com/signup/1)}
+  * [numverify.com](https://numverify.com/) — Global Phone Number Validation & Lookup JSON API. 250 API requests/month
+  * [sumome.com](https://sumome.com/) — Heat map and conversion enhancement tools, free without few advanced features
+
+## Payment / Billing Integration
+
+  * [braintreepayments.com](https://braintreepayments.com/) — Credit Card, Paypal, Venmo, Bitcoin, Apple Pay,... integration. Single and Recurrent Payments. First $50,000 are free of charge
+  * [taxratesapi.avalara.com](http://taxratesapi.avalara.com/) — Get the right sales tax rates to charge for the close to 10,000 sales tax jurisdictions in the USA. Free REST API. Registration required
+  * [currencylayer.com](https://currencylayer.com/) — Reliable Exchange Rates & Currency Conversion for your Business, 1,000 API requests/month free
+  * [vatlayer.com](https://vatlayer.com/) — Instant VAT Number Validation & EU VAT Rates API, free 100 API requests/month
+
+## Other Packs
+
+  * [education.github.com](https://education.github.com/pack) — As long as you're a student at a recognized university or US high school
+  * [screenshotlayer.com](https://screenshotlayer.com/) — Capture highly customizable snapshots of any website. Free 100 snapshots/month
+
+## Docker Related
+### Alternate Hosting
+
+  * [quay.io](https://quay.io/) — Unlimited free public repositories
+
+### PaaS
+
+  * [tutum.co](https://tutum.co/) — The Docker Platform for Dev and Ops, Build, deploy, and manage your apps across any cloud, free while in beta and free developer plan when tutum will be production ready
+
+## Vagrant Related
+### Vagrant Box Indexes
+
+  * [atlas.hashicorp.com](https://atlas.hashicorp.com/boxes/search) — HashiCorp's index of boxes
+  * [vagrantbox.es](http://vagrantbox.es/) — An alternative public box index
+
+## Technology Watch
+  * [apichangelog.com](https://apichangelog.com/) — Subscribe to be notified each time API Documentation is updated (Facebook, Twitter, Google,...)
+
+## Data Mining
+  * [monkeylearn.com](http://monkeylearn.com/) — Text analysis with Machine Learning, 100,000 queries for free/month
+  * [wit.ai](https://wit.ai/) — NLP for developers
+  * [wolfram.com](https://wolfram.com/language/) — Built-in knowledge based algorithms in the cloud
+
+## Other Lists
+  * [github.com - FOSS for Dev](https://github.com/httpsGithubParty/FOSS-for-Dev) — A hub of free and Open Source software for developers
+  * [github.com - Free for nonprofit](https://github.com/pborreli/free-for-nonprofit) — List of free services for non-profit organisations
+  * [fullcontact.com](https://fullcontact.com/developer/pricing/) — Help your users know more about their contacts by adding social profile into your app. 500 free Person API matches/month
+  * [getawesomeness.com](http://getawesomeness.com/) — Retrieve all amazing awesomeness from GitHub... a must see


### PR DESCRIPTION
Cleaned with regex to have short link markdown, [name](url)

github seems to have some problem with the link/ref on top... changes are not 'logical'
ok on third party validator, perhaps just the preview?