### PR TITLE
Add report-uri CSP and HPKP violation reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Table of Contents
   * [bitninja.io](https://bitninja.io/) — Botnet protection through a blacklist, free plan only reports limited information on each attack
   * [onelogin.com](https://www.onelogin.com/) — Identity as a Service (IDaaS), Single Sign-On Identity Provider, Cloud SSO IdP, 3 company apps and 5 personal apps, unlimited users
   * [logintc.com](https://www.logintc.com/) — Two-factor authentication (2FA) by push notifications, free for 10 users, VPN, Websites and SSH
+  * [report-uri.io](https://report-uri.io/) - CSP and HPKP violation reporting
 
 ## Management System
 


### PR DESCRIPTION
If the server sets the Content-Security-Policy-Report-Only header, the browser will report violations of the content security policy to the given webhook. report-uri.io is a free service to log such violations.