### PR TITLE
Added Assembla back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Table of Contents
   * [visualstudio.com](https://www.visualstudio.com/) — Free unlimited private repos (Git and TFS) for up to 5 users per team
   * [fogcreek.com](https://www.fogcreek.com/kiln/) — Free unlimited public and private repos (hybrid of Git and Mercurial) for 2 users
   * [plasticscm.com](https://plasticscm.com/) — Free for individuals, OSS and nonprofits organizations
+  * [assembla.com](https://www.assembla.com/repositories/) — Free private Subversion, Git, and Perforce repositories
   * [cloud.google.com](https://cloud.google.com/tools/cloud-repositories/) — Free private Git repositories hosted on Google Cloud Platform. Supports syncing with existing GitHub and Bitbucket repos. Free Beta for up to 500 MB of storage
 
 ## Tools for Teams and Collaboration


### PR DESCRIPTION
I think that Assembla may have been mistakenly removed. The old text listed a 7 day trial which appears to be for their task management tools, not their repos.  The page I linked to claims that the repos are still free and doesn't list a time limit. If this isn't suitable, could someone provide the reason why?