### PR TITLE
Deploybot no longer have a free plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ Table of Contents
   * [deployhq.com](http://www.deployhq.com/) — 1 project with 10 daily deployments
   * [hub.jazz.net](https://hub.jazz.net/) — 60 minutes of free build time/month
   * [styleci.io](https://styleci.io/) — Public GitHub repositories only
-  * [deploybot.com](http://deploybot.com/) — Free for 1 repository, private or public. Supports any service you can throw at it
   * [bitrise.io](https://www.bitrise.io/) — iOS CI/CD with 200 free builds/month
   * [saucelabs.com](https://saucelabs.com/) — CI with scalable testing for mobile and web apps, free for Open Source
   * [buddybuild.com](https://www.buddybuild.com/) — Build, deploy and gather feedback for your iOS and Android apps in one seamless, iterative system.


### PR DESCRIPTION
If they do I can't find it.
Their sign up page doesn't mention it https://signup.deploybot.com/signup/new