### PR TITLE
Warn about x10hosting's country restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Table of Contents
   * [contentful.com](https://www.contentful.com/) — Content as a Service. Content management and delivery APIs in the cloud. 3 users, 3 spaces (repositories) and 100,000 API requests/month for free
   * [tilda.cc](https://tilda.cc/) — One site, 50 pages, 50 MB storage, only the main pre-defined blocks among 170+ available, no fonts, no favicon and no custom domain
   * [pubstorm.com](http://www.pubstorm.com) — Free static content hosting with global CDN and custom domain support. 10 free sites, each with 2 past revisions
-  * [https://x10hosting.com] - Free hosting on http://USERNAME.x10host.com or severeal other domains.
+  * [https://x10hosting.com] - Free hosting on http://USERNAME.x10host.com or severeal other domains. There are some country restrictions.
 
 ## DNS
   * [freedns.afraid.org](https://freedns.afraid.org/) — Free DNS hosting


### PR DESCRIPTION
> Sorry, we're not able to accept your registration.
> We are not currently accepting new users from Brazil. Please try again at a later date. We are expanding our allowed country list in the upcoming days.

It's an old issue for some countries. See [this](https://x10hosting.com/community/threads/x10hosting-country-block-just-remove-it.164342/). 

Maybe it would be good to add 