### PR TITLE
rm code.fosshub.com - permclosed

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,6 @@ Table of Contents
 ## Web Hosting
 
   * [closeheat.com](https://closeheat.com/) — Development Environment in the Cloud for Static Websites with Free Hosting and GitHub integration. 1 free website with custom domain support
-  * [code.fosshub.com](https://code.fosshub.com/) — Free service offered by FossHub. Free hosting for Open Source projects
   * [sourceforge.net](https://sourceforge.net/) — Find, Create and Publish Open Source software for free
   * [simplybuilt.com](https://www.simplybuilt.com/) — free website building and hosting for {[Open Source projects](http://www.simplybuilt.com/explore/free-websites-for-open-source-projects)}. Simple alternative to GitHub Pages
   * [devport.co](http://devport.co/) — Turn GitHub projects, apps and websites into a personal developer portfolio


### PR DESCRIPTION
Source: [Official Statement by FossHub_com on Reddit, linked from mainpage](https://www.reddit.com/r/sysadmin/comments/4vzovk/fosshub_statement_regarding_2nd_august_security/).

_"As a response to this, we will be temporary shut down OldFoss to clean this, our repository for older versions and we decided to **close down permanently Code.FossHub.com** a free service that we offered hoping it will help some free projects after Google Code was deprecated. We will not abandon the existing, legit users who still use it and will continue to offer them the same service."_