### PR TITLE
Add TryStack - Free Openstack hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Table of Contents
   * [cloud.google.com/compute](https://cloud.google.com/compute/) — Google Compute Engine gives USD 300 over 60 days
   * [virtzone.net](http://www.virtzone.net/) — Free VPS. You must meet certain minor qualifications
   * [backblaze.com](https://backblaze.com/b2/) — Backblaze B2 cloud storage. Free 10 GB (Amazon S3-like) object storage for unlimited time
+  * [trystack.org](http://trystack.org/) — Free Openstack hosting. The environment is resets every 24 hours, suitable for testing only.
 
 ## DBaaS
 


### PR DESCRIPTION
Free Openstack hosting, suitable for testing only because they reset the environment every 24 hours.