### PR TITLE
renamed mongolab.com to mlab.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Table of Contents
    * [graphstory.com](http://graphstory.com/) — GraphStory offers Neo4j (a Graph Database) as a service
    * [elephantsql.com](http://www.elephantsql.com/) — PostgreSQL as a service, 20 MB free
    * [graphenedb.com](http://www.graphenedb.com/) — Neo4j as a service, up to 1,000 nodes and 10,000 relations free
-   * [mongolab.com](https://mongolab.com/) — MongoDB as a service, 500 MB free
+   * [mlab.com](https://mlab.com/) — MongoDB as a service, 500 MB free
    * [scalingo.com](https://scalingo.com/) — Primarily a PaaS but offers a 512 MB free tier of MySQL, PostgreSQL or MongoDB
    * [skyvia.com](https://skyvia.com/) — Cloud Data Platform, offers free tier and all plans are completely free while in beta
    * [airtable.com](https://airtable.com/) — Looks like a spreadsheet, but it's a relational database, unlimited bases, 1,200 rows/base and 1,000 API requests/month


### PR DESCRIPTION
In February 2016 MongoLab.com changed it's name to mLab.com

source:
https://techcrunch.com/2016/02/29/mongolab-is-now-mlab/