### PR TITLE
Remove Codepunker CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,6 @@ Table of Contents
   * [netdepot.com](https://www.netdepot.com/cdn/) — First 100 GB free/month
   * [speeder.io](https://speeder.io/) — Uses KeyCDN. Automatic image optimization and free CDN boost. Free and does not require any server changes
   * [jare.io](http://www.jare.io) — You should login using your GitHub account and register your domain. Uses AWS CloudFront
-  * [codepunker.com](https://www.codepunker.com/tools/cdn) — Uses CacheFly CDN. Free CDN for static assets (CSS and JavaScript files)
 
 ## PaaS
 


### PR DESCRIPTION
Directly quoting the website

```
This tool has been removed because of multiple flooding attempts and it will not be re-enabled.
Those who used it legitimately until now may continue to use it until April, 20th 2017 
when all assets will be deleted without any other notice.

We apologize to all those who have been harmed in any way.
```