### PR TITLE
remove snap-ci.com from CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Table of Contents
   * [wercker.com](http://wercker.com/) — Free for public and private repositories
   * [semaphoreci.com](https://semaphoreci.com/) — 100 private builds/month, unlimited for Open Source
   * [shippable.com](https://app.shippable.com/) — Free for 1 build container, private and public repos, unlimited builds
-  * [snap-ci.com](https://snap-ci.com/) — Free for public repositories, 1 build at the time
   * [appveyor.com](http://www.appveyor.com/) — CD service for Windows, free for Open Source
   * [github.com](https://github.com/ligurio/Continuous-Integration-services) — Comparison of Continuous Integration services
   * [ftploy.com](http://ftploy.com/) — 1 project with unlimited deployments


### PR DESCRIPTION
snap-ci is end-of-life and will shutdown in August:
 https://blog.snap-ci.com/blog/2017/02/06/2017-02-06-snap-announcement/