### PR TITLE
Add assertible.com to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Table of Contents
   * [appbeat.io](https://appbeat.io) — Website monitoring, 3 monitors free. They offer very reliable and affordable monitor service.
   * [dnsspy.io](https://dnsspy.io) — Monitor your DNS and get alerts for changes, RFC-violating DNS configs, ... Free for 1 domain, open source maintainers may apply for a free premium account.
   * [monique.io](https://monique.io) — Create dashboards directly from SQL results, JSON data, API respones, Unix commands' output. Define alarms in Javascript. Free for 25000 submissions per month.
+  * [assertible.com](https://assertible.com) - Automated API testing and monitoring. Free plans for teams and individuals.
 
 ## Crash and Exception Handling
 


### PR DESCRIPTION
Hey @ripienaar - thanks for this list, really great aggregation of resources. This adds [assertible.com](assertible.com) to the *Monitoring* section with a note about free plans usage.

Happy to make any updates necessary! Thanks :)