### PR TITLE
Add letsmonitor.org and http2.pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Table of Contents
   * [dnsspy.io](https://dnsspy.io) — Monitor your DNS and get alerts for changes, RFC-violating DNS configs, ... Free for 1 domain, open source maintainers may apply for a free premium account.
   * [monique.io](https://monique.io) — Create dashboards directly from SQL results, JSON data, API respones, Unix commands' output. Define alarms in Javascript. Free for 25000 submissions per month.
   * [assertible.com](https://assertible.com) - Automated API testing and monitoring. Free plans for teams and individuals.
+  * [letsmonitor.org](http://letsmonitor.org/) - TLS certificate expiration and connectivity monitoring with email and SMS alerts.
 
 ## Crash and Exception Handling
 

--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Table of Contents
   * [screenshotmachine.com](https://screenshotmachine.com/) — Capture 100 snapshots/month, png, gif and jpg, including full-length captures, not only home page
   * [readme.io](https://readme.io/) — Beautiful documentations made easy, free for Open Source
   * [formaholic.com](https://formaholic.com) — Simple form endpoint. Perfect for static sites
+  * [http2.pro](https://http2.pro) — HTTP/2 protocol readiness test and client HTTP/2 support detection API.
 
 ## APIs, Data and ML
 


### PR DESCRIPTION
Thanks for the awesome list. I discovered many awesome tools thanks to this. 

Can we add these two services as well, please?
 - letsmonitor.org - Free certificate expiration monitoring. 
 - http2.pro - HTTP/2 protocol server readiness test and client support API. 

Thanks. 