### PR TITLE
Update sendgrid's free details

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Table of Contents
   * [tinyletter.com](https://tinyletter.com/) — 5,000 subscribers/month free
   * [mailchimp.com](http://mailchimp.com/) — 2,000 subscribers and 12,000 emails/month free
   * [sendloop.com](https://sendloop.com/) — 2,000 subscribers and 10,000 emails/month free
-  * [sendgrid.com](https://sendgrid.com/) — 12,000 emails/month and 2,000 contacts free
+  * [sendgrid.com](https://sendgrid.com/) — 100 emails/day and 2,000 contacts free
   * [phplist.com](https://phplist.com/) — Hosted version allow 300 emails/month free
   * [mailjet.com](https://www.mailjet.com/) — 6,000 emails/month free
   * [sendinblue.com](https://www.sendinblue.com/) — 9,000 emails/month free


### PR DESCRIPTION
According to sendgrid's [pricing page](https://sendgrid.com/pricing/), you get a specific plan during the free trial and then get throttled down to 100 emails/day after that (forever). Still allowed 2,000 contacts for free.