### PR TITLE
Remove runscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ Table of Contents
   * [newrelic.com](https://newrelic.com/) — Free with 24 hours data retention
   * [nodequery.com](https://nodequery.com/) — Free basic server monitor up to 10 servers
   * [watchsumo.com](http://www.watchsumo.com/) — Free website monitoring, 50 http(s), Ping or keywords, every 5+ minutes
-  * [runscope.com](https://www.runscope.com/) — Monitor and log API usage. Single user 25,000 requests/month free
   * [circonus.com](http://www.circonus.com/) — Free for 20 metrics
   * [uptimerobot.com](https://uptimerobot.com/) — Website monitoring, 50 monitors free
   * [statuscake.com](https://www.statuscake.com/) — Website monitoring, unlimited tests free with limitations


### PR DESCRIPTION
Runscope has removed the free plan from their [pricing page](https://www.runscope.com/pricing-and-plans)