### PR TITLE
Removed Free-For-Nonprofit from Other Free Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,5 @@ Table of Contents
 
 ## Other Free Resources
   * [github.com - FOSS for Dev](https://github.com/httpsGithubParty/FOSS-for-Dev) — A hub of free and Open Source software for developers
-  * [github.com - Free for nonprofit](https://github.com/pborreli/free-for-nonprofit) — List of free services for nonprofit organizations
   * [getawesomeness](https://getawesomeness.herokuapp.com) — Retrieve all amazing awesomeness from GitHub... a must see
   * [education.github.com](https://education.github.com/pack) — Collection of free services for students. Registration required


### PR DESCRIPTION
The list hasn't been updated in 3 years, and is basically incomplete.