### PR TITLE
migadu.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Table of Contents
   * [elasticemail.com](https://elasticemail.com) — First 150,000 emails/month free
   * [appmail.io](https://appmail.io) — First 10,000 emails free
   * [mail-tester.com](https://www.mail-tester.com) — Test if email's dns/spf/dkim/dmarc settings are correct, 20 free/month
+  * [migadu.com](https://www.migadu.com/) — Email Hosting (Webmail, SMTP, IMAP, ...) - free plan is limited to 10 outgoing mails/day
 
 ## CDN and Protection
 


### PR DESCRIPTION
proposing migadu.com email hosting:
limited outgoing mails but still useful for receiving. 
even supports subdomains.