### PR TITLE
Fixing url play-with-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Table of Contents
   * [quay.io](https://quay.io/) — Build and store container images with unlimited free public repositories
   * [canister.io](https://canister.io/) — 20 free private repositories for developers, 30 free private repositories for teams to build and store Docker images
   * [Whales](https://github.com/Gueils/whales) - A tool to automatically dockerize your applications for free.
-  * [PWD](https://play-with-docker.com/) - Play with Docker. A simple, interactive and fun playground to learn Docker
+  * [PWD](https://labs.play-with-docker.com/) - Play with Docker. A simple, interactive and fun playground to learn Docker
  
 ## Vagrant Related
 


### PR DESCRIPTION
It seems that the url of previous PR is not doing redirect no more, I'm sorry.

#868 #869 