### PR TITLE
Removed abandoned IaaS items

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,10 +418,8 @@ Table of Contents
   * [aws.amazon.com](https://aws.amazon.com/free/) — AWS Free Tier, free for 12 months
   * [developer.rackspace.com](https://developer.rackspace.com/) — Rackspace Cloud gives USD 50/month for 12 months
   * [cloud.google.com/compute](https://cloud.google.com/compute/) — Google Compute Engine gives USD 300 over 12 months
-  * [virtzone.net](http://www.virtzone.net/) — Free VPS. You must meet certain minor qualifications
   * [backblaze.com](https://backblaze.com/b2/) — Backblaze B2 cloud storage. Free 10 GB (Amazon S3-like) object storage for unlimited time
   * [trystack.org](http://trystack.org/) — Free Openstack hosting. The environment is resets every 24 hours, suitable for testing only
-  * [dply.co](https://dply.co/) — Create a cloud server FREE for 2 hours. Backend host is Digitalocean.
 
 ## DBaaS
 


### PR DESCRIPTION
virtzone.net and dply.co are down, and seem abandoned.

dply.co - Last Twitter message on Jan 16, and last repo update in February.
virtzone.net - No signs of life
