### PR TITLE
RIP Atlassian Stride. Current Stride customers are converted to Slack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Table of Contents
   * [meet.jit.si](https://meet.jit.si/) — One click video conversations, screen sharing, for free
   * [flowdock.com](https://www.flowdock.com/) — Chat and inbox, free for teams up to 5
   * [slack.com](https://slack.com/) — Free for unlimited users with some feature limitations
-  * [stride.com](https://www.stride.com/) — Free for unlimited users with some feature limitations
   * [gitter.im](https://gitter.im/) — Chat, for GitHub. Unlimited public and private rooms, free for teams up to 25
   * [hangouts.google.com](https://hangouts.google.com/) — One place for all your conversations, for free, need a Google account
   * [seafile.com](https://www.seafile.com/) — Private or cloud storage, file sharing, sync, discussions. Private version is full. Cloud version has just 1 GB


### PR DESCRIPTION
Slack has acquired Atlassian Stride a month ago. The current customers are converted to Slack in the next months. Let's not direct anyone to Stride. See https://venturebeat.com/2018/07/26/slack-acquires-hipchat-and-stride-from-atlassian/