### PR TITLE
Remove instant.cm

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ thorization. Free for up to 1000 monthly active users.
   * [transifex.com](https://www.transifex.com/) — Free for Open Source
   * [oneskyapp.com](http://www.oneskyapp.com/) — Limited free edition for up to 5 users, free for Open Source
   * [crowdin.com](https://crowdin.com/) — Unlimited projects, unlimited strings and collaborators for Open Source
-  * [instant.cm](https://instant.cm/) — Free for up to 2 languages and 20,000 requests/month
   * [Loco](https://localise.biz/) - Free up to 2000 translations, Unlimited translators, 10 languages/project, 1000 translatable assets/project
 
 ## Monitoring


### PR DESCRIPTION
[Instant.cm](https://instant.cm/) redirects to [Unless.com](https://unless.com/) which means that Instant.cm probably does not exist anymore.