### PR TITLE
Remove watchsumo.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ thorization. Free for up to 1000 monthly active users.
   * [keymetrics.io](https://keymetrics.io/) — Free for 2 servers and 1 user
   * [newrelic.com](https://newrelic.com/) — Free with 24 hours data retention
   * [nodequery.com](https://nodequery.com/) — Free basic server monitor up to 10 servers
-  * [watchsumo.com](http://www.watchsumo.com/) — Free website monitoring, 50 http(s), Ping or keywords, every 5+ minutes
   * [circonus.com](http://www.circonus.com/) — Free for 20 metrics
   * [uptimerobot.com](https://uptimerobot.com/) — Website monitoring, 50 monitors free
   * [statuscake.com](https://www.statuscake.com/) — Website monitoring, unlimited tests free with limitations


### PR DESCRIPTION
[Watchsumo.com](https://www.watchsumo.com) does not offer a free tier anymore.
They only offer a 30 day trial as stated on their [pricing page](https://www.watchsumo.com/pricing).