### PR TITLE
Remove athenalayer.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,6 @@ thorization. Free for up to 1000 monthly active users.
   * [incapsula.com](https://www.incapsula.com/) — Free CDN and DDoS protection
   * [fastly.com](https://www.fastly.com/) — Free CDN, all features until USD 50/month is reached, enough for most, then pay or suspended
   * [Web Support Revolution](https://w.tools/) — Free CDN, backup, firewall, antivirus and monitoring.
-  * [athenalayer.com](http://athenalayer.com/) — Free DDoS protection with unlimited websites
   * [section.io](https://www.section.io/) — A simple way to spin up and manage a complete Varnish Cache solution. Supposedly free forever for one site
   * [netdepot.com](https://www.netdepot.com/cdn/) — First 100 GB free/month
   * [speeder.io](https://speeder.io/) — Uses KeyCDN. Automatic image optimization and free CDN boost. Free and does not require any server changes


### PR DESCRIPTION
[Athenalayer.com](http://athenalayer.com/) redirects to [OrcaTech](https://orca.tech/web-tools/) which means that it probably does not exist anymore.