### PR TITLE
Remove atlas.hashicorp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,6 @@ thorization. Free for up to 1000 monthly active users.
 
 ## Vagrant Related
 
-  * [atlas.hashicorp.com](https://atlas.hashicorp.com/boxes/search) — HashiCorp's index of boxes
   * [vagrantbox.es](http://vagrantbox.es/) — An alternative public box index
 
 ## Miscellaneous


### PR DESCRIPTION
Remove atlas.hashicorp.com because it does not exist anymore