### PR TITLE
Rename placehold.it to placeholder.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ thorization. Free for up to 1000 monthly active users.
    * [podio.com](https://podio.com/) — You can use Podio with a team of up to five people and try out the features of the Basic Plan, except users management
    * [shrinkray.io](https://shrinkray.io/) — Free image optimization of GitHub repos
    * [kraken.io](https://kraken.io/) — Image optimization for website performance as a service, free plan up to 1 MB file size
-   * [placehold.it](https://placehold.it/) — A quick and simple image placeholder service
+   * [placeholder.com](https://placeholder.com/) — A quick and simple image placeholder service
    * [placekitten.com](https://placekitten.com/) — A quick and simple service for getting pictures of kittens for use as placeholders
    * [embed.ly](http://embed.ly/) — Provides APIs for embedding media in a webpage, responsive image scaling, extracting elements from a webpage. Free for up to 5,000 URLs/month at 15 requests/second
    * [backhub.co](https://backhub.co/) — Backup and archive your GitHub repositories. Free for public repos


### PR DESCRIPTION
[Placehold.it](https://placehold.it) got renamed and now redirects to [placeholder.com](https://placeholder.com)