### PR TITLE
Remove taxratesapi.avalara.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,6 @@ thorization. Free for up to 1000 monthly active users.
 ## Payment / Billing Integration
 
   * [braintreepayments.com](https://braintreepayments.com/) — Credit Card, Paypal, Venmo, Bitcoin, Apple Pay,... integration. Single and Recurrent Payments. First USD 50,000 free
-  * [taxratesapi.avalara.com](http://taxratesapi.avalara.com/) — Get the right sales tax rates to charge for the close to 10,000 sales tax jurisdictions in the USA. Free REST API. Registration required
   * [currencylayer.com](https://currencylayer.com/) — Reliable Exchange Rates and Currency Conversion for your Business, 1,000 API requests/month free
   * [vatlayer.com](https://vatlayer.com/) — Instant VAT number validation and EU VAT rates API, free 100 API requests/month
   * [fraudlabspro.com](https://www.fraudlabspro.com) - Help merchants to prevent payment fraud and chargebacks. Free Micro Plan available with 500 queries/month.


### PR DESCRIPTION
[taxratesapi.avalara.com](http://taxratesapi.avalara.com/) redirects to https://developer.avalara.com/avatax/signup/ which seems to only have a free trial as seen on the [Overview page](https://developer.avalara.com/avatax/).