### PR TITLE
Rename copr.fedoraproject.org to copr.fedorainfracloud.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,12 +519,12 @@ thorization. Free for up to 1000 monthly active users.
    * [latlong.net](https://www.latlong.net/) — Geocoding API + school districts, census geography divisons and other address based data. 2,500 free requests/month
    * [mapbox.com](https://mapbox.com/) — Maps, geospatial services and SDKs for displaying map data
    * [osmnames](https://osmnames.org/) — Geocoding, search results ranked by the popularity of related Wikipedia page
-   * [maptiler.com](https://www.maptiler.com) — Vector maps, map services and SDKs for map visualisation. Free vector tiles with weekly update and four map styles.
+   * [tilehosting](https://www.tilehosting.com/) — Vector maps, map services and SDKs for map visualisation. Free vector tiles with weekly update and four map styles.
 
 ## Package Build System
 
    * [build.opensuse.org](https://build.opensuse.org/) — Package build service for multiple distros (SUSE, EL, Fedora, Debian etc.)
-   * [copr.fedoraproject.org](https://copr.fedoraproject.org/) — Mock-based RPM build service for Fedora and EL
+   * [copr.fedorainfracloud.org](https://copr.fedorainfracloud.org) — Mock-based RPM build service for Fedora and EL
    * [help.launchpad.net](https://help.launchpad.net/Packaging) — Ubuntu and Debian build service
 
 ## IDE and Code Editing


### PR DESCRIPTION
[copr.fedoraproject.org](https://copr.fedoraproject.org) redirects to [copr.fedorainfracloud.org](https://copr.fedorainfracloud.org).