### PR TITLE
Rename opbeat.com to elastic.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ thorization. Free for up to 1000 monthly active users.
 ## Monitoring
 
   * [cloudsploit.com](https://cloudSploit.com) — AWS security and configuration monitoring. Free: unlimited on-demand scans, unlimited users, unlimited stored accounts. Subscription: automated scanning, API access, etc
-  * [opbeat.com](https://opbeat.com/) — ​Instant performance insights for JS developers. Free with 24 hours data retention
+  * [elastic.co](https://www.elastic.co/solutions/apm) — ​Instant performance insights for JS developers. Free with 24 hours data retention
   * [appneta.com](http://www.appneta.com/) — Free with 1 hour data retention
   * [thousandeyes.com](https://www.thousandeyes.com/) — Network and user experience monitoring. 3 locations and 20 data feeds of major web services free
   * [datadoghq.com](https://www.datadoghq.com/) — Free for up to 5 nodes


### PR DESCRIPTION
[Opbeat.com](https://opbeat.com) redirects to [elastic.co](https://www.elastic.co).
Their [APM product](https://www.elastic.co/solutions/apm) seems to be what opbeat.com was.
They offer a free tier as stated [here](https://www.elastic.co/subscriptions)