### PR TITLE
Remove websitetest.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Table of Contents
   * [scan.coverity.com](https://scan.coverity.com/) — Static code analysis for Java, C/C++, C# and JavaScript, free for Open Source
   * [webceo.com](https://www.webceo.com/) — SEO tools but with also code verifications and different type of advices
   * [zoompf.com](https://zoompf.com/) — Fix the performance of your web sites, detailed analysis
-  * [websitetest.com](http://websitetest.com/) — Yotta's tool to optimize web sites, free limited version online
   * [gtmetrix.com](https://gtmetrix.com/) — Reports and thorough recommendations to optimize websites
   * [browserling.com](https://www.browserling.com/) — Live interactive cross-browser testing, free only 3 minutes sessions with MS IE 9 under Vista at 1024 x 768 resolution
   * [shields.io](https://shields.io) — Quality metadata badges for open source projects


### PR DESCRIPTION
[Websitetest.com](http://websitetest.com/) redirects to [Yottaa.com](https://www.yottaa.com) who were the creators of websitetest.com.
It seems like websitetest.com does not exist anymore.