### PR TITLE
Renamed sonarqube.com to sonarcloud.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Table of Contents
   * [blamewarrior.com](https://blamewarrior.com/) — Tool to automatically assign reviewers for new pull requests and track statistics of review process, free for Open Source
   * [gerrithub.io](https://review.gerrithub.io/) — Gerrit code review for GitHub repositories for free
   * [reviewable.io](https://reviewable.io/) — Code review for GitHub repositories, free for public or personal repos
-  * [sonarqube.com](https://sonarqube.com) — Automated source code analysis for Java, JavaScript, C/C++, C#, VB.NET, PHP, Objective-C, Swift, Python, Groovy and even more languages, free for Open Source
+  * [sonarcloud.io](https://sonarcloud.io) — Automated source code analysis for Java, JavaScript, C/C++, C#, VB.NET, PHP, Objective-C, Swift, Python, Groovy and even more languages, free for Open Source
   * [golangci.com](https://golangci.com) — Automated Go (golang) code review service for GitHub pull requests.
 
 ## Code Search and Browsing


### PR DESCRIPTION
[Sonarqube.com](https://sonarqube.com) redirects to [sonarcloud.io](https://sonarcloud.io).