### PR TITLE
Rename deveo.com to perforce.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Table of Contents
   * [buddy.works](https://buddy.works/) — One free private project with a Git repository and continuous delivery integrated
   * [codebasehq.com](https://www.codebasehq.com/) — One free project with 100 MB space and 2 users
   * [NotABug](https://notabug.org) - NotABug.org is a free-software code collaboration platform for freely licensed projects, Git-based
-  * [Deveo](https://deveo.com/) - [free](https://deveo.com/pricing/) cloud and  Git, Mercurial, or SVN repositories.
+  * [perforce.com](https://www.perforce.com/products/helix-teamhub) - Free 1GB Cloud and  Git, Mercurial, or SVN repositories.
   * [projectlocker.com](https://projectlocker.com) — One free private project (Git and Subversion) with 50 MB space
 
 ## Artifact Repos


### PR DESCRIPTION
[Deveo.com](https://deveo.com) redirects to [Perforce.com](https://www.perforce.com/products/helix-teamhub). They still have something similar looking available with a free tier so I am assuming that it is the same.