### PR TITLE
Remove konacloud.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ thorization. Free for up to 1000 monthly active users.
   * [backendless.com](https://backendless.com/) — Mobile and Web Baas, with 1 GB file storage free, push notifications 50000/month, and 1000 data objects in table.
    * [hasura.io](https://www.hasura.io/) — Platform to build and deploy app backends fast, free for single node cluster.
   * [pusher.com](https://pusher.com/beams/) - Free, unlimited push notifications for 2000 monthly active users. A single API for iOS and Android devices.
-  * [konacloud.io](http://konacloud.io/) — Web and Mobile Backend as a Service, with 5 GB free account
   * [layer.com](https://layer.com/) — The full-stack building block for communications
   * [quickblox.com](http://quickblox.com/) — A communication backend for instant messaging, video and voice calling and push notifications
   * [pushbots.com](https://pushbots.com/) — Push notification service. Free for up to 1.5 million pushes/month


### PR DESCRIPTION
[Konacloud.io](https://konacloud.io) redirects to [kona.tech](https://kona.tech) which isn't the same and does not show any pricing upfront.