### PR TITLE
Remove trystack.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,6 @@ thorization. Free for up to 1000 monthly active users.
   * [developer.rackspace.com](https://developer.rackspace.com/) — Rackspace Cloud gives USD 50/month for 12 months
   * [cloud.google.com/compute](https://cloud.google.com/compute/) — Google Compute Engine gives USD 300 over 12 months
   * [backblaze.com](https://backblaze.com/b2/) — Backblaze B2 cloud storage. Free 10 GB (Amazon S3-like) object storage for unlimited time
-  * [trystack.org](http://trystack.org/) — Free Openstack hosting. The environment is resets every 24 hours, suitable for testing only
 
 ## DBaaS
 


### PR DESCRIPTION
[Trystack.org](https://trystack.org) redirects to [openstack.org](https://openstack.org).
They seem to offer only offer a free trial as stated [here](https://www.openstack.org/software/start).