### PR TITLE
Rename cloudant.com to ibm.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ thorization. Free for up to 1000 monthly active users.
 
 ## DBaaS
 
-   * [cloudant.com](https://cloudant.com/) — Hosted database from IBM, free if usage is below USD 50/month
+   * [ibm.com](https://www.ibm.com/cloud/cloudant) — Hosted database from IBM, 1 GB free
    * [orchestrate.io](https://orchestrate.io/) — 1 application free
    * [redislabs.com](https://redislabs.com/redis-cloud) — Redis as a Service, 30 MB and 30 concurrent connections free
    * [zenginehq.com](http://www.zenginehq.com/) — Build business workflow apps in minutes, free for single users


### PR DESCRIPTION
[Cloudant.com](https://cloudant.com) redirects to [ibm.com](https://www.ibm.com/cloud/cloudant)