### PR TITLE
Rename bitballoon.com to app.netlify.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ thorization. Free for up to 1000 monthly active users.
   * [netlify.com](https://www.netlify.com/) — Builds, deploy and hosts static site or app, free for 100 GB data and 100 GB/month bandwidth
   * [pantheon.io](https://pantheon.io/) — Drupal and WordPress hosting, automated DevOps and scalable infrastructure. Free for developers and agencies
   * [acquia.com](https://www.acquia.com/) — Hosting for Drupal sites. Free tier for developers. Free development tools (such as Acquia Dev Desktop) also available
-  * [bitballoon.com](https://www.bitballoon.com/) — Hosting for static sites and apps. Free on a subdomain
+  * [app.netlify.com](https://app.netlify.com/drop) — Hosting for static sites and apps. Free on a subdomain
   * [readthedocs.org](https://readthedocs.org/) — Free documentation hosting with versioning, PDF generation and more
   * [bubble.is](https://bubble.is/) — Visual programming to build web and mobile apps without code, free 100 visitors/month, 2 apps
   * [contentful.com](https://www.contentful.com/) — Content as a Service. Content management and delivery APIs in the cloud. 3 users, 3 repositories and 100,000 API requests/month for free


### PR DESCRIPTION
[Bitballoon.com](https://bitballoon.com) redirects to [app.netlify.com](https://app.netlify.com/drop).