### PR TITLE
Remove zenginehq.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,6 @@ thorization. Free for up to 1000 monthly active users.
    * [cloudant.com](https://cloudant.com/) — Hosted database from IBM, free if usage is below USD 50/month
    * [orchestrate.io](https://orchestrate.io/) — 1 application free
    * [redislabs.com](https://redislabs.com/redis-cloud) — Redis as a Service, 30 MB and 30 concurrent connections free
-   * [zenginehq.com](http://www.zenginehq.com/) — Build business workflow apps in minutes, free for single users
    * [redsmin.com](https://redsmin.com/) — Online real-time monitoring and administration service for Redis, 1 Redis instance free
    * [graphstory.com](http://graphstory.com/) — GraphStory offers Neo4j (a Graph Database) as a service
    * [elephantsql.com](http://www.elephantsql.com/) — PostgreSQL as a service, 20 MB free


### PR DESCRIPTION
[Zenginehq.com](http://zenginehq.com) redirects to [wizehive.com](https://www.wizehive.com/zengine) which only mentions a [free trial](https://auth.zenginehq.com/users/signup).