### PR TITLE
Remove appacitive.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,6 @@ thorization. Free for up to 1000 monthly active users.
 
 ## BaaS
 
-  * [appacitive.com](http://appacitive.com/) — Mobile backend, free for the first 3 months with 100,000 API calls, push notifications
   * [blockspring.com](https://www.blockspring.com/) — Cloud functions. Free for 5 million runs/month
   * [kinvey.com](http://www.kinvey.com/) — Mobile backend, starter plan has unlimited requests/second, with 2 GB of data storage, as well as push notifications for up 5 million unique recipients. Enterprise application support
   * [backendless.com](https://backendless.com/) — Mobile and Web Baas, with 1 GB file storage free, push notifications 50000/month, and 1000 data objects in table.


### PR DESCRIPTION
[Appacitive.com](https://appacitive.com) no longer exists.