### PR TITLE
Remove sendloop...again

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ Table of Contents
   * [sparkpost.com](https://www.sparkpost.com/) — First 15,000 emails/month free
   * [mailgun.com](https://www.mailgun.com/) — First 10,000 emails/month free
   * [tinyletter.com](https://tinyletter.com/) — 5,000 subscribers/month free
-  * [sendloop.com](https://start.sendloop.com/) — 2,000 subscribers and unlimited emails/month free
   * [mailchimp.com](https://mailchimp.com/) — 2,000 subscribers and 12,000 emails/month free
   * [sendgrid.com](https://sendgrid.com/) — 100 emails/day and 2,000 contacts free
   * [phplist.com](https://phplist.com/) — Hosted version allow 300 emails/month free


### PR DESCRIPTION
I removed sendloop around this time last year, with #783. It was added back in #788 referencing a forever free plan. The https://start.sendloop.com now redirects to just https://sendloop.com and there is this bit on their [pricing page](https://sendloop.com/pricing/):

> Can I use Sendloop for free?
Unfortunately we don’t have a free plan. Building and maintaining a world class email delivery infrastructure costs a lot. Sendloop has one of the biggest email delivery platform and the small amount of fee we charge to you helps us a lot to keep this platform active.