### PR TITLE
mLab is acquired by MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,6 @@ Table of Contents
    * [graphstory.com](https://graphstory.com/) — GraphStory offers Neo4j (a Graph Database) as a service
    * [elephantsql.com](https://www.elephantsql.com/) — PostgreSQL as a service, 20 MB free
    * [graphenedb.com](https://www.graphenedb.com/) — Neo4j as a service, up to 1,000 nodes and 10,000 relations free
-   * [mlab.com](https://mlab.com/) — MongoDB as a service, 500 MB free
    * [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) — free tier gives 512 MB
    * [scalingo.com](https://scalingo.com/) — Primarily a PaaS but offers a 512 MB free tier of MySQL, PostgreSQL or MongoDB
    * [skyvia.com](https://skyvia.com/) — Cloud Data Platform, offers free tier and all plans are completely free while in beta


### PR DESCRIPTION
mLab is acquired by MongoDB and customers will be migrated to MongoDB Atlas.
https://blog.mlab.com/2018/10/mlab-is-becoming-a-part-of-mongodb-inc/