### PR TITLE
Add humio.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Table of Contents
 
 ## Log Management
 
+  * [humio.com](https://www.humio.com/) — Free up to 2 GB/day with 7 days retention
   * [logentries.com](https://logentries.com/) — Free up to 5 GB/month with 7 days retention
   * [loggly.com](https://www.loggly.com/) — Free for a single user, see the lite option
   * [logz.io](https://logz.io/) — Free up to 1 GB/day, 3 days retention


### PR DESCRIPTION
Hosted log management with free tier of 2GB/day.

Details of free tier can be found here https://www.humio.com/pricing
