### PR TITLE
Reflect Github Pricing change

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Table of Contents
 
 ## Source Code Repos
 
+  * [github.com](https://github.com/) — Unlimited public repositories and unlimited private repositories (up to 3 collaborators)
   * [bitbucket.org](https://bitbucket.org/) — Unlimited public and private repos (Git and Mercurial) for up to 5 users with Pipelines for CI/CD
   * [chiselapp.com](http://chiselapp.com/) — Unlimited public and private Fossil repositories
-  * [github.com](https://github.com/) — Unlimited number of public repositories
   * [about.gitlab.com](https://about.gitlab.com/) — Unlimited public and private Git repos with unlimited collaborators
   * [visualstudio.com](https://www.visualstudio.com/) — Unlimited private repos (Git and TFS) for up to 5 users/team
   * [plasticscm.com](https://plasticscm.com/) — Free for individuals, OSS and nonprofit organizations


### PR DESCRIPTION
This PR reflects the new [Github Pricing](https://github.com/pricing) whereby private repositories are now free (with limits, such as 3 collaborators max).