### PR TITLE
Removed letsmonitor.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ Table of Contents
   * [healthchecks.io](https://healthchecks.io) — Monitor your cron jobs and background tasks. Free for up to 20 checks.
   * [appbeat.io](https://appbeat.io) — Website monitoring, 3 monitors free. They offer very reliable and affordable monitor service.
   * [assertible.com](https://assertible.com) — Automated API testing and monitoring. Free plans for teams and individuals.
-  * [letsmonitor.org](https://letsmonitor.org/) — TLS certificate expiration and connectivity monitoring with email and SMS alerts.
   * [opsgenie.com](https://www.opsgenie.com/) — Powerful alerting and on-call management for operating always-on services. Free up to 5 users.
 
 ## Crash and Exception Handling


### PR DESCRIPTION
Removed letsmonitor.org because while the site is still running, they are not actively monitoring SSL certs.