### PR TITLE
added gitpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ Table of Contents
    * [stackblitz.com](https://stackblitz.com/) — Online VS Code IDE for Angular & React
    * [cacher.io](https://www.cacher.io) - Code snippet organizer with labels and support for 100+ programming languages
    * [Coder](https://coder.com) - Platform that gives you a whole development environment build around Visual Studio Code. In the free tier you will get 2GB of project and 2 GB of container space as well as 5 hours of Fast Time that dynamically scales your container up if enabled.
+   * [gitpod.io](https://gitpod.io) - Instant, ready-to-code dev environmments for GitHub projects. Free for open-source.
 
 ## Analytics, Events and Statistics
 


### PR DESCRIPTION
This PR adds gitpod.io under IDEs.

It is a free online service that lets you start coding on any GitHub repo instantly.
Just prefix the github repo's URL with `https://gitpod.io#`.

For instance you can review this PR in Gitpod: 
[https://gitpod.io#https://github.com/ripienaar/free-for-dev/pull/1020](https://gitpod.io#https://github.com/ripienaar/free-for-dev/pull/1020)