### PR TITLE
Added index.html for Github Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-dupe --allow-ssl --allow-redirect | grep -Ev "\s*?[0-9]{1,4}\.\s*?http"
+  - awesome_bot README.md --allow-dupe --allow-ssl --allow-redirect --set-timeout 5 | grep -Ev "\s*?[0-9]{1,4}\.\s*?http"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="UTF-8">
+  <title>Free for developers</title>
+  <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
+</head>
+<body>
+  <div id="app">Loading...</div>
+  <script>
+    window.$docsify = {
+      name: 'Free for developers',
+      repo: 'ripienaar/free-for-dev',
+      search: ['/']
+    }
+  </script>
+  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What's changed?
Added an index.html so that the repo could be served as a site using Github Pages.

### Why would we want to serve as a website?
 - Much easier to browse on mobile devices.
 - Integrated search means using Ctrl F is no longer needed
 - Cleaner UI. Site can also be later styled to look better.
 - Uses [docsify](https://github.com/docsifyjs/docsify), so the site is generated automatically from README.md
 - In the future, we could serve on a custom domain, but let's not get too ahead of ourselves :P
 - See a demo [here](https://c0derlint.github.io/free-for-dev).

What do you think?