### PR TITLE
Update free package limits for DeployHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Table of Contents
   * [appveyor.com](https://www.appveyor.com/) — CD service for Windows, free for Open Source
   * [github.com](https://github.com/ligurio/Continuous-Integration-services) — Comparison of Continuous Integration services
   * [ftploy.com](https://ftploy.com/) — 1 project with unlimited deployments
-  * [deployhq.com](https://www.deployhq.com/) — 1 project with 10 daily deployments
+  * [deployhq.com](https://www.deployhq.com/) — 1 project with 10 daily deployments (30 build minutes/month)
   * [styleci.io](https://styleci.io/) — Public GitHub repositories only
   * [buddybuild.com](https://www.buddybuild.com/) — Build, deploy and gather feedback for your iOS and Android apps in one seamless, iterative system
   * [gitlab.com](https://about.gitlab.com/gitlab-ci/) — Create pipelines directly from Git repositories using GitLab's CI service.  2,000min/mo


### PR DESCRIPTION
Like a lot of the other deployment services, DeployHQ's [build pipeline](https://www.deployhq.com/features/build-pipelines) feature lets you define a series of commands to be ran whenever you deploy your application or website.

In this pull request I've simply added the number of build minutes given to free users. Let me know if you need me to change anything.

Thanks!