### PR TITLE
replace datamaps.co with datamaps.world

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ Table of Contents
 
    * [opencagedata.com](https://opencagedata.com) — Geocoding API that aggregates OpenStreetMap and other open geo sources. 2,500 free queries/day
    * [graphhopper.com](https://www.graphhopper.com/) A free package for developers is offered for Routing, Route Optimization, Distance Matrix, Geocoding, Map Matching.
-   * [datamaps.co](https://datamaps.co/) — a free platform for creating visualizations with data maps
+   * [datamaps.world](https://datamaps.world/) — The simple, yet powerful platform that gives you tools to visualize your geospatial data with a free tier.
    * [geocod.io](https://www.geocod.io/) — Geocoding via API or CSV Upload. 2,500 free queries/day
    * [gogeo.io](https://gogeo.io/) — Maps and geospatial services with an easy to use API and support for big data
    * [carto.com](https://carto.com/) — Create maps and geospatial APIs from your data and public data


### PR DESCRIPTION
Datamaps.world is a next version of the datamaps.co platform. It offers paid plans but it also includes a generous free tier.