### PR TITLE
Correct a typo in currencystack.io description

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ Table of Contents
   * [currencylayer.com](https://currencylayer.com/) — Reliable Exchange Rates and Currency Conversion for your Business, 1,000 API requests/month free
   * [vatlayer.com](https://vatlayer.com/) — Instant VAT number validation and EU VAT rates API, free 100 API requests/month
   * [fraudlabspro.com](https://www.fraudlabspro.com) — Help merchants to prevent payment fraud and chargebacks. Free Micro Plan available with 500 queries/month.
-  * [currencystack.io](https://currencystack.io/) — Production-re3ady real-time exchange rates for 154 currencies.
+  * [currencystack.io](https://currencystack.io/) — Production-ready real-time exchange rates for 154 currencies.
 ## Docker Related
 
   * [Docker Hub](https://hub.docker.com) — One free private repository and unlimited public repositories to build and store Docker images


### PR DESCRIPTION
Under the payments/billing section, currencystack was listed as 
`currencystack.io — Production-re3ady real-time exchange rates for 154 currencies.`

We remove the stray `3`.