### PR TITLE
Remove BrainTreePayments

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,6 @@ Table of Contents
 
 ## Payment / Billing Integration
 
-  * [braintreepayments.com](https://www.braintreepayments.com/) — Credit Card, Paypal, Venmo, Bitcoin, Apple Pay,... integration. Single and Recurrent Payments. First USD 50,000 free
   * [currencylayer.com](https://currencylayer.com/) — Reliable Exchange Rates and Currency Conversion for your Business, 1,000 API requests/month free
   * [vatlayer.com](https://vatlayer.com/) — Instant VAT number validation and EU VAT rates API, free 100 API requests/month
   * [fraudlabspro.com](https://www.fraudlabspro.com) — Help merchants to prevent payment fraud and chargebacks. Free Micro Plan available with 500 queries/month.


### PR DESCRIPTION
BrainTree is no longer offering this promotion: https://twitter.com/braintree/status/859109104350105602?lang=en. See also the notice at the top of the announcement of this promotion: https://www.braintreepayments.com/blog/ignition-first-50k-on-us/.