### PR TITLE
Add noscript fallback for index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
 </head>
 <body>
+  <noscript>This page requires JavaScript to work, please enable it or just read it on <a href="https://github.com/ripienaar/free-for-dev">Here</a>.</noscript>
   <div id="app">Loading...</div>
   <script>
     window.$docsify = {


### PR DESCRIPTION
I found that someone complains that this `free-for.dev` won't work if JavaScript are disabled, so I add a message to instruct them to enable it or read it on GitHub.

Complains:
https://news.ycombinator.com/item?id=21287000
https://www.reddit.com/r/programming/comments/djw9qi/list_of_software_that_has_free_tiers_for/f49w8tk/