### PR TITLE
Add ZEIT Now to Web Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Table of Contents
   * [cloudno.de](https://cloudno.de/) — Free cloud hosting for Node.js apps.
   * [heliohost.org](https://www.heliohost.org) — Community powered free hosting for everyone.
  * [render.com](https://render.com) — A unified platform to build and run all your apps and web app free SSL, a global CDN, private networks and auto deploys from Git, free for static web page.
+  * [zeit.co/now](https://zeit.co/now) — Serverless platform with support for multiple languages (including static sites) and single command deployment. Free tier includes SSL, 20GB bandwidth, 100 deployments.
 
 ## DNS
 


### PR DESCRIPTION
This PR adds ZEIT Now to the Web Hosting section.