### PR TITLE
fix broken link without http protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ Table of Contents
   * [Sender](https://www.sender.net) Up to 15 000 emails/month - Up to 2 500 subscribers
   * [Buttondown](https://buttondown.email/) — Newsletter service. Up to 1,000 subscribers free
   * [Substack](https://substack.com) — Unlimited free newsletter service. Start paying when you charge for it.
-  * [10minutemail](10minutemail.com) - Free, temporary email for testing.
-  * [Mailnesia](mailnesia.com) - Free temporary/disposable email, which auto visit registration link.
+  * [10minutemail](https://10minutemail.com) - Free, temporary email for testing.
+  * [Mailnesia](https://mailnesia.com) - Free temporary/disposable email, which auto visit registration link.
   * [ImprovMX](https://improvmx.com) – Free email forwarding
 
 ## CDN and Protection


### PR DESCRIPTION
Few links are without `https://` protocol, which result in redirect to relative path (broken link). So I added `https://` protocol.