### PR TITLE
Swiftype no longer offer a free plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,6 @@ Table of Contents
 ## Search
 
   * [algolia.com](https://www.algolia.com/) — Hosted search-as-you-type (instant). Free hacker plan up to 10,000 documents and 100,000 operations. Bigger free plans available for community/Open Source projects
-  * [swiftype.com](https://swiftype.com/) — Hosted search solution (API and crawler). Free for a single search engine with up to 1,000 documents. Free upgrade to premium level for Open Source
   * [bonsai.io](https://bonsai.io/) — Free 1 GB memory and 1 GB storage
   * [searchly.com](http://www.searchly.com/) — Free 2 indices and 5 MB storage
 


### PR DESCRIPTION
Source: https://brownbox.net.au/swiftype-silently-drops-free-and-low-cost-plans/