### PR TITLE
Adding Typo CI - Spellchecker for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Table of Contents
   * [lgtm.com](https://lgtm.com) — Continuous security analysis for Java, Python, JavaScript, TypeScript, C#, C and C++, free for Open Source
   * [deepscan.io](https://deepscan.io) — Advanced static analysis for automatically finding runtime errors in JavaScript code, free for Open Source
   * [Imgbot](https://github.com/marketplace/imgbot) — Imgbot is a friendly robot that optimizes your images and saves you time. Optimized images mean smaller file sizes without sacrificing quality. It's free for open source.
+  * [Typo CI](https://github.com/marketplace/typo-ci) — Typo CI reviews your Pull Requests and commits for spelling mistakes, free for Open Source.
 
 ## Code Search and Browsing
 


### PR DESCRIPTION
This adds https://github.com/marketplace/typo-ci to the list :)