### PR TITLE
Added VSCodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@ Table of Contents
    * [JDoodle](https://www.jdoodle.com) — Online compiler and editor for more than 60 programming languages with a free plan for REST API code compiling up to 200 credits per day.
    * [Atom](https://atom.io/) - Atom is a hackable text editor built on Electron.
    * [Visual Studio Code](https://code.visualstudio.com/) - Code editor redefined and optimized for building and debugging modern web and cloud applications. Developed by Microsoft for Windows, macOS and Linux.
+   * [VSCodium](https://vscodium.com/) - Community-driven, without telemetry/tracking, and freely-licensed binary distribution of Microsoft’s editor VSCode
 
 ## Analytics, Events and Statistics
 


### PR DESCRIPTION
Microsoft’s `vscode` source code is open source (MIT-licensed), but the the product available for download (Visual Studio Code) is licensed under not-FLOSS license and contains telemetry/tracking. VSCodium is a community-driven, freely-licensed binary distribution of Microsoft’s editor VSCode.