### PR TITLE
Added Eclipse Che among IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,7 @@ Table of Contents
    * [Atom](https://atom.io/) - Atom is a hackable text editor built on Electron.
    * [Visual Studio Code](https://code.visualstudio.com/) - Code editor redefined and optimized for building and debugging modern web and cloud applications. Developed by Microsoft for Windows, macOS and Linux.
    * [VSCodium](https://vscodium.com/) - Community-driven, without telemetry/tracking, and freely-licensed binary distribution of Microsoft’s editor VSCode
+   * [Eclipse Che](https://www.eclipse.org/che/) - Web based and Kubernetes-Native IDE for Developer Teams with multi-language support. Open Source and community driven. An hosted version is available at [che.openshift.io](https://che.openshift.io/)
 
 ## Analytics, Events and Statistics
 


### PR DESCRIPTION
[Che is a web based IDE](https://www.eclipse.org/che/) featured recently on [The New Stack](https://thenewstack.io/eclipse-che-7-goes-kubernetes-native-leaves-eclipse-ide-behind/).

**Disclaimer:** I am one of Che maintainers