### PR TITLE
fixes incorrect myfakeapi.com indention

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Table of Contents
   * [MailboxValidator](https://www.mailboxvalidator.com) — Email verification service using real mail server connection to confirm valid email. Free API plan has 300 verifications per month.
   * [microlink.io](https://microlink.io/) – It turns any website into data such as metatags normalization, beauty link previews, scraping capabilities or screenshots as a service. 250 reqs/day every day free.
   * [monkeylearn.com](https://monkeylearn.com/) — Text analysis with machine learning, free 300 queries/month
-   * [myfakeapi.com](https://myfakeapi.com) — Free serverless API mocking service for developers
+  * [myfakeapi.com](https://myfakeapi.com) — Free serverless API mocking service for developers
   * [OCR.Space](https://ocr.space/) — An OCR API which parses image and pdf files returning the text results in JSON format. 25,000 requests per month free.
   * [parsehub.com](https://parsehub.com/) — Extract data from dynamic sites, turn dynamic websites into APIs, 5 projects free
   * [Pixela](https://pixe.la/) - Free daystream database service. All operations are performed by API. Visualization with heat maps and line graphs is also possible.


### PR DESCRIPTION
_myfakeapi.com_ was showing up as a nested list rather than a list item because of an extra space before the `*`. 

Screenshot of original problem:
<img width="410" alt="Screen Shot 2019-12-16 at 2 05 57 AM" src="https://user-images.githubusercontent.com/15053417/70889699-d06d1d00-1fa8-11ea-9fbe-169f2bb546b4.png">
