### PR TITLE
Kuber.host have no real free plan anymore :(

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,6 @@ Table of Contents
   * [kubesail.com](https://kubesail.com) - Managed Kubernetes namespace service designed for developers. Free developer accounts come with with 1 Core of CPU, 512MB of RAM, 100MB of storage and 1 domain.
   * [okteto.com](https://okteto.com) - Managed Kubernetes service designed for developers. Free developer accounts come with three namespaces, each with 8GB of RAM, 4 CPUs and 150GB Disk space.
   * [K8Spin](https://k8spin.cloud) - Managed Kubernetes namespace service designed for developers. Free developer accounts come with with 100 mCore of CPU, 128MB of RAM.
-  * [kuber.host](https://kuber.host/) — Kubernetes Namespace as a Service free plan. Free up to 600MiB RAM, 0.3 vCPU Core, 10 Pods and 600MiB Persistent Storage.
   * [mendix.com](https://www.mendix.com/) — Rapid Application Development for Enterprises, unlimited number of free sandbox environments supporting 10 users, 100 MB of files and 100 MB database storage each
   * [outsystems.com](https://www.outsystems.com/) — Enterprise web development PaaS for on-premise or cloud, free "personal environment" offering allows for unlimited code and up to 1 GB database
   * [pipedream.com](https://pipedream.com) - An integration platform built for developers. Develop any workflow, based on any trigger. Workflows are code, which you can run [for free](https://docs.pipedream.com/pricing/). No server or cloud resources to manage.


### PR DESCRIPTION
I know there's still a free plan you can have but it shutdown automatically after 30 days. It's more testing plan than free plan.

So I think it should be removed from the list. Sad.