### PR TITLE
Added restdb.io to DBaaS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Table of Contents
    * [remotemysql.com](https://remotemysql.com) — Remote MySQL Database hosting, setup is instant and use phpMyAdmin for administration, free for 100Mb data, free backups, no query limits and 99% uptime.
    * [InfluxDB](https://www.influxdata.com/) — Timeseries database, free up to 3MB/5 minutes writes, 30MB/5 minutes reads and 10,000 cardinalities series
    * [Quickmetrics](https://www.quickmetrics.io/) — Timeseries database with dashboard included, free up to 10,000 events/day and total of 5 metrics.
+   * [restdb.io](https://restdb.io/) - a fast and simple NoSQL cloud database service. With restdb.io you get schema, relations, automatic REST API (with MongoDB-like queries) and an efficient multi-user admin UI for working with data. Free plan allows 3 users, 2500 records and 1 API requests per second.
 
 ## STUN, WebRTC, Web Socket Servers and Other Routers
 


### PR DESCRIPTION
I'm not sure if restdb.io belongs under APIs, Data and ML or the DBaaS list. I added it to the latter.