### PR TITLE
Add Howuku into Analytics and Visitor Recordings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,7 +871,6 @@ Table of Contents
 
 ## Visitor Session Recording
 
-   * [howuku.com](https://howuku.com) — 200 sessions/month with 1 month data retention.
    * [FullStory.com](https://www.fullstory.com) — 1,000 sessions/month with 1 month data retention and 3 user seats. More information [here](https://help.fullstory.com/hc/en-us/articles/360020623354-FullStory-Free-Edition).
    * [hotjar.com](https://www.hotjar.com/) — Per site: 2,000 pages views/day, 3 heatmaps, data stored for 3 months,...
    * [inspectlet.com](https://www.inspectlet.com/) — 100 sessions/month free for 1 website

--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ Table of Contents
 
 ## Analytics, Events and Statistics
 
+   * [howuku.com](https://howuku.com) — Track user interaction, engagement, and event. Free for up to 5,000 visits/month
    * [amplitude.com](https://amplitude.com/) — 1 million monthly events, up to 2 apps
    * [analytics.google.com](https://analytics.google.com/) — Google Analytics
    * [expensify.com](https://www.expensify.com/) — Expense reporting, free personal reporting approval workflow
@@ -870,6 +871,7 @@ Table of Contents
 
 ## Visitor Session Recording
 
+   * [howuku.com](https://howuku.com) — 200 sessions/month with 1 month data retention.
    * [FullStory.com](https://www.fullstory.com) — 1,000 sessions/month with 1 month data retention and 3 user seats. More information [here](https://help.fullstory.com/hc/en-us/articles/360020623354-FullStory-Free-Edition).
    * [hotjar.com](https://www.hotjar.com/) — Per site: 2,000 pages views/day, 3 heatmaps, data stored for 3 months,...
    * [inspectlet.com](https://www.inspectlet.com/) — 100 sessions/month free for 1 website


### PR DESCRIPTION
I would like to add my new analytics platform [howuku.com](https://howuku.com) into the list which comes with a freemium plan.