### PR TITLE
DemosWP will closes on MAY 01, 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,6 @@ Table of Contents
   * [tilda.cc](https://tilda.cc/) — One site, 50 pages, 50 MB storage, only the main pre-defined blocks among 170+ available, no fonts, no favicon and no custom domain
   * [txti.es](http://txti.es/) — Quickly create web pages with markdown.
   * [Versoly](https://versoly.com/) — SaaS focussed website builder - unlimited websites, 70+ blocks, 5 templates, custom CSS, favicon, SEO and forms. No custom domain.
-  * [DemosWP](https://demoswp.dev/) — WordPress free hosting for tests and development sites.
 
 ## DNS
 


### PR DESCRIPTION
Official news:

https://blog.demoswp.dev/cierra-demoswp/