### PR TITLE
Add LeanCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Table of Contents
   * [streamdata.io](https://streamdata.io/) — Turns any REST API into an event-driven streaming API. Free plan up to 1 million messages and 10 concurrent connections
   * [tyk.io](https://tyk.io/) — API management with authentication, quotas, monitoring and analytics. Free cloud offering
   * [zapier.com](https://zapier.com/) — Connect the apps you use, to automate tasks. 5 zaps, every 15 minutes and 100 tasks/month
+  * [LeanCloud](https://leancloud.app/) — Mobile backend. 1GB of data storage, 256MB instance, 3K API requests/day, 10K pushes/day are free. (API is very similar to Parse Platform)
 
 ## Web Hosting
 


### PR DESCRIPTION
Mobile backend. 1GB of data storage, 256MB instance, 3K API requests/day, 10K pushes/day are free. (API is very similar to Parse Platform)

https://leancloud.app/pricing/
https://docs.leancloud.app/leanengine_plan.html#hash-849507193

Their DC is located in Los Angeles.
I am using the free plan on their China site since 2015, and works fine now.