### PR TITLE
Remove Selectel DNS Geo zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Table of Contents
   * [noip](https://www.noip.com/) — a dynamic dns service that allows up to 3 hostnames free with confirmation every 30 days
   * [ns1.com](https://ns1.com/) — Data Driven DNS, automatic traffic management, 500k free queries
   * [pointhq.com](https://pointhq.com/developer) — Free DNS hosting on Heroku.
-  * [selectel.com](https://selectel.com/services/dns/) — Free DNS hosting, anycast, 10 geo zones
+  * [selectel.com](https://selectel.com/services/dns/) — Free DNS hosting, anycast
   * [web.gratisdns.dk](https://web.gratisdns.dk/domaener/dns/) — Free DNS hosting.
   * [Yandex.Connect](https://connect.yandex.com/pdd/) — Free email and DNS hosting for up to 1,000 users
   * [zilore.com](https://zilore.com/ru/dns) — Free DNS hosting.


### PR DESCRIPTION
Seems that they don't provide GeoDNS...
https://kb.selectel.com/docs/cloud-services/dns-hosting/dns_hosting/