### PR TITLE
Removed formaholic

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,6 @@ Table of Contents
 ## Forms
 
   * [99inbound.com](https://www.99inbound.com/) - Build forms and share them online. Get an email or Slack message for each submission. Free plan has 2 forms, 100 entries per month, basic email & Slack.
-  * [formaholic.com](https://formaholic.com) — Simple form endpoint. Perfect for static sites.
   * [Formcarry.com](https://formcarry.com) - HTTP POST Form endpoint, Free plan allows 100 submissions per month.
   * [formingo.co](https://www.formingo.co/)- Easy HTML forms for static websites, get started for free without registering an account. Free plan allows 500 submissions per month, customizable reply-to email address.
   * [formlets.com](https://formlets.com/) — Online forms, unlimited single page forms/month, 100 submissions/month, email notifications.


### PR DESCRIPTION
I check the Forms section regularly and I've seen this message on formaholic for some time (couple of months) now:

"Signups are currently disabled due to abuse"