### PR TITLE
Remove rollbar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,6 @@ Table of Contents
   * [loggly.com](https://www.loggly.com/) — Free for a single user, see the lite option
   * [logz.io](https://logz.io/) — Free up to 3 GB/day, 3 days retention
   * [papertrailapp.com](https://papertrailapp.com/) — 48 hours search, 7 days archive, 100 MB/month
-  * [rollbar.com](https://rollbar.com) — Free up to 5000 events/month, 30 days retention
   * [sematext.com](https://sematext.com/logsene) — Free up to 500 MB/day, 7 days retention
   * [splunk.com](https://www.splunk.com) - Free for a single user, 500 MB/day
   * [sumologic.com](https://www.sumologic.com/) — Free up to 500 MB/day, 7 days retention


### PR DESCRIPTION
Rollbar is no longer free for dev, its only a 15 day trial now.

I just tested this myself a couple weeks ago and got this email from them today:

![image](https://user-images.githubusercontent.com/2934507/80380518-4e99d400-8865-11ea-8f5e-0b955ac004fa.png)

The button says "trial" in it. 

![image](https://user-images.githubusercontent.com/2934507/80380711-8dc82500-8865-11ea-9d1f-d11815626584.png)

When you click the button, the next modal clearly says "Start your free 14-day trial of Rollbar":

![image](https://user-images.githubusercontent.com/2934507/80380816-b4865b80-8865-11ea-8486-d27cf7f5111f.png)

