### PR TITLE
Added forwardemail.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Table of Contents
   * [Contact.do](https://contact.do/) — Contact form in a link (bitly for contact forms) - totally free!
   * [debugmail.io](https://debugmail.io/) — Easy to use testing mail server for developers
   * [elasticemail.com](https://elasticemail.com) — 100 free emails/day. 1,000 emails for $0.09 through API (pay as you go).
+  * [forwardemail.net](https://forwardemail.net) — Free email forwarding for custom domains. Create and forward an unlimited amount of email addresses with your domain name.
   * [ImprovMX](https://improvmx.com) – Free email forwarding
   * [inumbo.com](http://inumbo.com/) — SMTP based spam filter, free for 10 users
   * [kickbox.io](https://kickbox.io/) — Verify 100 emails free, real-time API available


### PR DESCRIPTION
[forwardemail.net](https://forwardemail.net/) provides free email forwarding for custom domains. Create and forward an **unlimited** amount of email addresses with your domain name. In addition, you can get catch-all, wildcard, and disposable forwarding addresses.