### PR TITLE
Remove jsonstore (service has shut down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,7 +796,6 @@ Table of Contents
    * [gumlet.com](https://www.gumlet.com/) — Image resize-as-a-service. It also optimizes images and performs delivery via CDN. Free tier includes 1 GB bandwidth and unlimited number of image processing every month for 1 year.
    * [image-charts.com](https://www.image-charts.com/) — Unlimited image chart generation with a watermark
    * [jsonbin.io](https://jsonbin.io/) — Free JSON data storage service, ideal for small-scale web apps, website, mobile apps.
-   * [jsonstore.io](https://www.jsonstore.io/) — One click JSON storage endpoint
    * [kraken.io](https://kraken.io/) — Image optimization for website performance as a service, free plan up to 1 MB file size
    * [npoint.io](https://www.npoint.io/) — JSON store with collaborative schema editing
    * [otixo.com](https://www.otixo.com/) — Encrypt, share, copy and move all your cloud storage files from one place. Basic plan provides unlimited files transfer with 250 MB max. file size and allows 5 encrypted files


### PR DESCRIPTION
This PR removes [jsonstore.io](https://www.jsonstore.io/) from the "Storage and Media Processing" section, as it's shut down:

![image](https://user-images.githubusercontent.com/8850830/85949069-67e5fc00-b94c-11ea-9341-87ccda5f63dd.png)
