### PR TITLE
Add weblate.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Table of Contents
   * [POEditor](https://poeditor.com/) — Free up to 1000 strings
   * [transifex.com](https://www.transifex.com/) — Free for Open Source
   * [webtranslateit.com](https://webtranslateit.com/) — Free up to 500 strings
+  * [weblate.org](https://weblate.org/) — It's free for libre projects up to 10,000 string source for the free tier, and Unlimited Self-hosted on-premises.
 
 ## Monitoring
 


### PR DESCRIPTION
Web-based continuous localization, Copylefted libre software, used by over 1150 libre software projects and companies in over 115 countries.
P.S. it seems to be widely used, but not tested yet.