### PR TITLE
Remove title link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [free-for.dev](https://free-for.dev)
+# free-for.dev
 
 Developers and Open Source authors now have a massive amount of services offering free tiers, but it can be hard to find them all to make informed decisions.
 


### PR DESCRIPTION
There is a link in the title of the README.md document that breaks the generation of the left-side navigation bar in the docsify-rendered page at [free-for.dev](https://free-for.dev). It seems like docsify can't handle links in headings. I have removed the link in the document title and solved the rendering issue. You can find a "before-after" comparison attached below:

| With a link in the title | Without a link in the title |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/60352933/94787155-3446c200-03d2-11eb-98ee-4636c85b7c72.png) | ![image](https://user-images.githubusercontent.com/60352933/94787423-956e9580-03d2-11eb-96d4-38c727c884b9.png) |

