### PR TITLE
Removed fast.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,5 @@ Table of Contents
   * [education.github.com](https://education.github.com/pack) — Collection of free services for students. Registration required
   * [Framacloud](https://degooglisons-internet.org/en/list/) — A list of Free/Libre Open Source Software and SaaS by the French non-profit [Framasoft](https://framasoft.org/en/).
   * [getawesomeness](https://getawesomeness.herokuapp.com) — Retrieve all amazing awesomeness from GitHub... a must see
-  * [github.com — FOSS for Dev](https://github.com/tvvocold/FOSS-for-Dev) — A hub of free and Open Source software for developers
-  * [fast.io](https://fast.io/) — Host PDFs, videos, images, etc. with direct links on a fast global network. Free and includes CDN, custom domains, and analytics. Free for Personal Projects includes 5 Sites, 500 MB per Files, Free 100 GB Usage / Month 
+  * [github.com — FOSS for Dev](https://github.com/tvvocold/FOSS-for-Dev) — A hub of free and Open Source software for developers 
   * [smsreceivefree.com](https://smsreceivefree.com/) — Provides free temporary and disposable phone numbers.


### PR DESCRIPTION
Reason=They sunsetted their free plan.