### PR TITLE
Clean up AWS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Table of Contents
     * Amazon CodeBuild - 100min of build time per month
     * Amazon Code Commit - 5 active users per month
     * Amazon Code Pipeline - 1 active pipeline per month
-    * Full, detailed list - https://aws.amazon.com/free/?awsf.Free%20Tier%20Types=categories%23alwaysfree
+    * Full, detailed list - https://aws.amazon.com/free/
 
   * [Microsoft Azure](https://azure.microsoft.com)
     * [Virtual Machines](https://azure.microsoft.com/services/virtual-machines/) - 1 B1S Linux VM, 1 B1S Windows VM


### PR DESCRIPTION
The new link goes to the same place, and displays more free services when the page loads. It matches the other links on the page better.