### PR TITLE
Add Container Registry Service that offer 1 GB of private image store for Free, perfect for devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,7 @@ Table of Contents
 ## Docker Related
 
   * [canister.io](https://canister.io/) — 20 free private repositories for developers, 30 free private repositories for teams to build and store Docker images
+  * [Container Registry Service](https://container-registry.com/) - Harbor based Container Management Solution. Free tier offers 1 GB storage for private repositories.
   * [Docker Hub](https://hub.docker.com) — One free private repository and unlimited public repositories to build and store Docker images
   * [Gitlab](https://gitlab.com) - Per-repo container registry.  10GB limit.
   * [Play with Docker](https://labs.play-with-docker.com/) — A simple, interactive and fun playground to learn Docker.


### PR DESCRIPTION
As a viable alternative to Docker Hub, this service offers free and unlimited private repositories for your side project or contract.

 https://container-registry.com/ is a  Harbor based Container Management Solution as a Service for teams and organizations. Free tier offers 1 GB storage for private repositories.