### PR TITLE
Add GitHub Actions to CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Table of Contents
   * [codeship.com](https://codeship.com/) — 100 private builds/month, 5 private projects, unlimited for Open Source
   * [deployhq.com](https://www.deployhq.com/) — 1 project with 10 daily deployments (30 build minutes/month)
   * [drone](https://cloud.drone.io/) - Drone Cloud enables developers to run Continuous Delivery pipelines across multiple architectures - including x86 and Arm (both 32 bit and 64 bit) - all in one place
+  * [GitHub Actions](https://github.com/features/actions) - Build, test, and deploy your code right from GitHub. 
   * [gitlab.com](https://about.gitlab.com/product/continuous-integration/) — Create pipelines directly from Git repositories using GitLab's CI service. 400 mins/mo per top-level group
   * [ligurio/awesome-ci](https://github.com/ligurio/awesome-ci) — Comparison of Continuous Integration services
   * [scalr.com](https://scalr.com/) - Remote state & operations backend for Terraform with full CLI support, integration with OPA and a hierarchical configuration model. Free up to 5 users.


### PR DESCRIPTION
This PR adds GitHub Actions with some adapted copy from https://github.com/features/actions.
Made the link text `GitHub Actions` instead of `https://github.com/features/actions`.

Cheers,
  Lee