### PR TITLE
Remove Whales from the Docker-related list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,6 @@ Table of Contents
   * [Gitlab](https://gitlab.com) - Per-repo container registry.  10GB limit.
   * [Play with Docker](https://labs.play-with-docker.com/) — A simple, interactive and fun playground to learn Docker.
   * [quay.io](https://quay.io/) — Build and store container images with unlimited free public repositories
-  * [Whales](https://github.com/Gueils/whales) — A tool to automatically dockerize your applications for free.
 
 ## Vagrant Related
 


### PR DESCRIPTION
Whales is currently broken because the Slack webhook token built into a sub-image it runs in Docker is invalid (why does it include a Slack hook?). It also involves sending information about your codebase to their Heroku-hosted service for the "secret sauce", which is not well advertised and doesn't seem to make sense or be necessary for the functionality of the product. I personally don't believe we should be advertising this service.