### PR TITLE
Please, remove Alibaba Cloud, its "free trial" is false advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,6 @@ Table of Contents
     * Log Analysis - 500MB of daily log
     * Full, detailed list - https://www.ibm.com/cloud/free/
 
-  * [Alibaba Cloud](https://www.alibabacloud.com/campaign/free-trial)
-    * Compute - 1 ecs.t5-lc1m1.small for 12 months with 40 GB ultra cloud disk or SSD disk and 1 MB internet bandwidth.
-    * Function Compute - 1 million calls free each month, 400,000 GB-seconds free each month
-    * API Gateway - For the 1st year you activate API Gateway, you get 1 million free calls each month.
-    * .tech Domain Name - Free to use for one year
-    * Full, detailed list - https://www.alibabacloud.com/campaign/free-trial
-
 ## Source Code Repos
 
   * [bitbucket.org](https://bitbucket.org/) — Unlimited public and private Git repos for up to 5 users with Pipelines for CI/CD


### PR DESCRIPTION
Take a look at these reviews, **2.1 stars** rating speaks volumes:

https://www.trustpilot.com/review/alibabacloud.com

I've had a very similar experience to some of those reviews. Worst customer experience/support I've ever seen in my life when dealing with cloud/hosting providers.

## Some juicy excerpts from reviews:
> They even ask for a complicated verification process to get a free trial, which at the end we DON'T get a real "free trial". They still DEDUCT the money from you for its service（Yes they do...). So there is a sense the free trial is created to lure people sign up and then choose the wrong package.

> they claim that they have a free trial, but once you sign up you get a message that you are not eligible for the trial... when you contact them they will tell you to send tons of documents including your ID or passport... and your bank statement

> I would give it a 0 if I could. Stay away. Words can not describe how bad they are. Their software is faulty: SMS does not come through, Credit cards do not debit, authorisations for Cards do not happen, their support people are clueless and tries to push blame onto others. I wasted 5 hours with their support - never again!

> I would give it a 0 star. Absolutely lousy, and worse, a thief that deduct money from your credit card and refuse to reverse it after complaint lodged in the rawest form - still pretend that they do not understand the problem.