### PR TITLE
add Acra — database security suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Table of Contents
 
 ## Security and PKI
 
+  * [Acra](https://marketplace.digitalocean.com/apps/acra) - SQL database protection suite: field-level encryption, masking, tokenization, available as database proxy or API service.
   * [alienvault.com](https://www.alienvault.com/open-threat-exchange/reputation-monitor) — Uncovers compromised systems in your network
   * [atomist.com](https://atomist.com/) — A quicker and more convenient way to automate a variety of development tasks. Now in beta.
   * [auth0.com](https://auth0.com/) — Hosted free for development SSO. Up to 2 social identity providers for closed-source projects.


### PR DESCRIPTION
That's a tool that allows encrypting/decrypting data "on the fly" before posting it to the database. Available as a free app on Digital Ocean, or as a free tool from Github (https://github.com/cossacklabs/acra) or as an Enterprise paid version (https://www.cossacklabs.com/acra/).

I we can count Acra-on-Digital-Ocean as SaaS, then it'd be a nice addition to security chapter.