### PR TITLE
Add free subdomain description to freedns.afraid.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ Table of Contents
   * [duckdns.org](https://www.duckdns.org/) — Free DDNS with up to 5 domains on the free tier. With configuration guides for various setups.
   * [dynu.com](https://www.dynu.com/) — Free dynamic DNS service
   * [fosshost.org](https://fosshost.org/) - Free open source hosting VPS, web, storage and mirror hosting
-  * [freedns.afraid.org](https://freedns.afraid.org/) — Free DNS hosting
+  * [freedns.afraid.org](https://freedns.afraid.org/) — Free DNS hosting. Also provide free subdomain based on numerous public user [contributed domains](https://freedns.afraid.org/domain/registry/). Get free subdomains from "Subdomains" menu after signing up.
   * [freenom.com](https://freenom.com/) — Free domain provider. Get FQDN for free.
   * [luadns.com](https://www.luadns.com/) — Free DNS hosting, 3 domains, all features with reasonable limits
   * [namecheap.com](https://www.namecheap.com/domains/freedns/) — Free DNS. No limit on number of domains


### PR DESCRIPTION
Added more description to `freedns.afraid.org` about it also provide free subdomain. Which I personally have test/use over the years and works pretty well.