### PR TITLE
Remove Splunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,6 @@ Table of Contents
   * [logz.io](https://logz.io/) — Free up to 3 GB/day, 3 days retention
   * [papertrailapp.com](https://papertrailapp.com/) — 48 hours search, 7 days archive, 100 MB/month
   * [sematext.com](https://sematext.com/logsene) — Free up to 500 MB/day, 7 days retention
-  * [splunk.com](https://www.splunk.com) - Free for a single user, 500 MB/day
   * [sumologic.com](https://www.sumologic.com/) — Free up to 500 MB/day, 7 days retention
 
 ## Translation Management


### PR DESCRIPTION
Hi! Splunk does offer a free installation, but it is self-hosted. Since this list excludes self-hosted offerings, I think it should be removed. [More context here](https://docs.splunk.com/Documentation/Splunk/8.1.2/Admin/MoreaboutSplunkFree).