### PR TITLE
Added freecurrencyapi.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,6 +1169,7 @@ Table of Contents
   * [namiml.com](https://www.namiml.com/) - Complete platform for in-app purchases and subscriptions on iOS and Android, including no-code paywalls, CRM, and analytics.  Free for all base features to run an IAP business.
   * [revenuecat.com](https://www.revenuecat.com/) — Hosted backend for in-app purchases and subscriptions (iOS and Android). Free up to $10k/mo in tracked revenue.
   * [vatlayer.com](https://vatlayer.com/) — Instant VAT number validation and EU VAT rates API, free 100 API requests/month
+  * [freecurrencyapi.net](https://freecurrencyapi.net/) — Free currency conversion and exchange rate data API. 10 requests/hour without an API key, 50 000 requests per month when you register for free.
 
 ## Docker Related
 


### PR DESCRIPTION
Free currency conversion and exchange rate data API. 10 requests/hour without an API key, 50 000 requests per month when you register for free.