### PR TITLE
add privacy management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Table of Contents
    * [PaaS](#paas)
    * [Package Build System](#package-build-system)
    * [Payment and Billing Integration](#payment-and-billing-integration)
+   * [Privacy Management](#privacy-management)
    * [Screenshot APIs](#screenshot-apis)
    * [Search](#search)
    * [Security and PKI](#security-and-pki)
@@ -539,7 +540,6 @@ Table of Contents
   * [appdynamics.com](https://www.appdynamics.com/) — Free for 24 hours metrics, application performance management agents limited to one Java, one .NET, one PHP and one Node.js
   * [appneta.com](https://www.appneta.com/) — Free with 1-hour data retention
   * [assertible.com](https://assertible.com) — Automated API testing and monitoring. Free plans for teams and individuals.
-  * [bearer.sh](https://www.bearer.sh) - Automatically Monitor API Requests, Track Performance, Detect Anomalies and Fix Issues on your critical API Usage. Install the Bearer Agent for Free with 1 line of code.
   * [blackfire.io](https://blackfire.io/) — Blackfire is the SaaS-delivered Application Performance Solution. Free Hacker plan (PHP only)
   * [checklyhq.com](https://checklyhq.com) - Open source E2E / Synthetic monitoring and deep API monitoring for developers. Free plan with 5 users and 50k+ check runs.
   * [circonus.com](https://www.circonus.com/) — Free for 20 metrics
@@ -1223,6 +1223,13 @@ Table of Contents
   * [JsLinux](https://bellard.org/jslinux) — a really fast x86 virtual machine capable of running Linux and Windows 2k.
   * [Jor1k](http://s-macke.github.io/jor1k/demos/main.html) —  a OpenRISC virtual machine capable of running Linux with network support.
   * [v86](https://copy.sh/v86) — a x86 virtual machine capable of running Linux and other OS directly into the browser.
+
+## Privacy Management
+  * [Bearer](https://www.bearer.sh/) - Helps implement privacy by design via audits and continuous workflows so that organizations comply with GDPR and other regulations. Free tier is limited to smaller teams and SaaS version only. 
+  * [Osano](https://www.osano.com/) - Consent management and compliance platform with everything from GDPR representation to cookie banners. Free tier offers basic features.
+  * [Iubenda](https://www.iubenda.com/) - Privacy and cookie policies along with consent management. Free tier offers limited privacy and cookie policy as well as cookie banners.
+  * [Cookiefirst](https://cookiefirst.com/) - Cookie banners, auditing, and multi-language consent management solution. Free tier offers a one-time scan and a single banner.
+  * [Ketch](https://www.ketch.com/) - Consent management and privacy framework tool. Free tier offers most features with a limited visitor count.
 
 ## Miscellaneous
 


### PR DESCRIPTION
Bearer is no longer an API monitoring tool, so this PR does a few things:
- Removes Bearer from the monitoring section
- Creates a new privacy management category for tools like consent and cookie management, gdpr compliance, etc.
- Adds a handful of services that fit the category.

To make things a bit easier, here are their pricing pages in order of appearance:
- https://www.bearer.sh/pricing
- https://www.osano.com/plans
- https://www.iubenda.com/en/pricing
- https://cookiefirst.com/#pricing
- https://www.ketch.com/packaging

Wasn't sure where to put the category itself, so I dropped it right before the misc section, but the ToC position is still alphabetical.