### PR TITLE
Remove SenseiTool.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,6 @@ Table of Contents
    * [plan.io](https://plan.io/) — Project Management with Repository Hosting and more options. Free for 2 users with 10 customers and 500MB Storage
    * [planitpoker.com](https://www.planitpoker.com/) — Free online planning poker (estimation tool)
    * [saas.zentao.pm](https://saas.zentao.pm/) - An Application Lifecycle Management solution for Issue Tracking and Project Management, on-premise and open source version are available as well.
-   * [senseitool.com](https://www.senseitool.com/) — An agile retrospective tool - Free.
    * [SpeedBoard](https://speedboard.app) - Board for Agile and Scrum retrospectives - Free.
    * [Shake](https://www.shakebugs.com/) - In-app bug reporting and feedback tool for mobile apps. Free plan, 10 bug reports per app/per month. 
    * [Tadum](https://tadum.app) - Meeting agenda and minutes app designed for recurring meetings, free for teams up to 10


### PR DESCRIPTION
SenseiTool.com has been retired. When visiting [senseitool.com](https://senseitool.com), you are redirected to the [SenseiTool Sunset page](https://lithespeed.com/senseisunset/).