### PR TITLE
Updated Oracle Cloud Free Tier offering

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Table of Contents
     * Full, detailed list - [https://azure.microsoft.com/free/](https://azure.microsoft.com/free/)
 
   * [Oracle Cloud](https://www.oracle.com/cloud/)
-    * Compute - 2 VM.Standard.E2.1.Micro 1GB RAM
-    * Block Volume - 2 volumes, 100 GB total (used for compute)
+    * Compute - 2 VM.Standard.E2.1.Micro 1GB RAM, 4 Arm-based Ampere A1 cores and 24 GB of memory usable as one VM or up to 4 VMs
+    * Block Volume - 2 volumes, 200 GB total (used for compute)
     * Object Storage - 10 GB
     * Load balancer - 1 instance with 10 Mbps
     * Databases - 2 DBs, 20 GB each


### PR DESCRIPTION
Recently Oracle have added ARM based Cloud Computing, and they've included it in free tier as well. Also block volumes is now 200 GB in total.

More info at: [Oracle Cloud Free Tier](https://www.oracle.com/in/cloud/free/#always-free)