### PR TITLE
Remove Adobe XD from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,7 +1089,6 @@ Table of Contents
 
 ## Design and UI
 
-  * [Adobe XD](https://www.adobe.com/products/xd.html) - Wireframe & Prototyping tool similar to Sketch. Free plan covers: 1 active shared design spec, Adobe Fonts Free (limited set of fonts), 2GB of cloud storage.
   * [Mockplus iDoc](https://www.mockplus.com/idoc) - Mockplus iDoc is a powerful design collaboration & handoff tool. Free Plan includes 3 users and 5 projects with all features available.
   * [AllTheFreeStock](https://allthefreestock.com) - a curated list of free stock images, audio and videos.
   * [Ant Design Landing Page](https://landing.ant.design/) - Ant Design Landing Page provides a template built by Ant Motion's motion components. It has a rich homepage template, downloads the template code package, and can be used quickly. You can also use the editor to quickly build your own dedicated page.


### PR DESCRIPTION
Apparently Adobe XD removed the free plan, and is paid now.

[Pricing](https://www.adobe.com/in/products/xd/pricing/individual.html)