### PR TITLE
Deleted unusable Travis Config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.4.1
-before_script:
-  - gem install awesome_bot
-script:
-  - awesome_bot README.md --allow-dupe --allow-ssl --allow-redirect --set-timeout 5 | grep -Ev "\s*?[0-9]{1,4}\.\s*?http"


### PR DESCRIPTION
This deletes the [Travis](https://travis.ci) YAML Config as it no longer runs builds. The credits are exhausted.