### PR TITLE
Added asayer.io - hosted version of open-source session replay openreplay/openreplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ Table of Contents
   * [uptimerobot.com](https://uptimerobot.com/) — Website monitoring, 50 monitors free
   * [uptimetoolbox.com](https://uptimetoolbox.com/) — Free monitoring for 5 websites, 60 second intervals, public statuspage.
   * [zenduty.com](https://www.zenduty.com/) — End-to-end incident management, alerting, on-call management and response orchestration platform for network operations, site reliability engineering and DevOps teams. Free for upto 5 users.
+  * [asayer.io](https://asayer.io/pricing.html) — Hosted version of openreplay, an open-source session replay (alternative to FullStory and LogRocket). Free 1k sessions/month with 14 days retention
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
The hosted version of https://github.com/openreplay/openreplay