### PR TITLE
Remove F5: they only do 30-day trials now

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,7 +970,6 @@ Table of Contents
   * [huaweicloud.com](https://www.huaweicloud.com/intl/en-us/product/dns.html) – Free DNS hosting by Huawei
   * [Hetzner](https://www.hetzner.com/dns-console) – Free DNS hosting from Hetzner with API support
   * [Glauca](https://docs.glauca.digital/hexdns/) – Free DNS hosting for up to 3 domains and DNSSEC support
-  * [F5](https://www.f5.com/products/ways-to-deploy/cloud-services/dns-cloud-service) – Free Anycast DNS hosting for primary zones. And free for secondary zones up to 1 domain and 3 million requests per month.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
It seems F5 used to offer a free tier ([web.archive.org, 2020](https://web.archive.org/web/20201130115238/https://www.f5.com/products/ways-to-deploy/cloud-services/dns-cloud-service)), but it's replaced by a 30-day trial ([f5.com](https://www.f5.com/products/ways-to-deploy/cloud-services/dns-cloud-service))