### PR TITLE
Add js.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,7 @@ Table of Contents
 
   * [education.github.com](https://education.github.com/pack) — Collection of free services for students. Registration required
   * [eu.org](https://nic.eu.org) — Free eu.org domain. Request is usually approved in 14 days.
+  * [js.org](https://js.org) - Free js.org domains for GitHub Pages
   * [pp.ua](https://nic.ua/) — Free pp.ua domain.
   * [Framacloud](https://degooglisons-internet.org/en/list/) — A list of Free/Libre Open Source Software and SaaS by the French non-profit [Framasoft](https://framasoft.org/en/).
   * [getawesomeness](https://getawesomeness.herokuapp.com) — Retrieve all amazing awesomeness from GitHub... a must see


### PR DESCRIPTION
Hi there!
I added [js.org](https://js.org/) which provides free .js.org subdomains for JavaScript related Projects (to be used with GitHub Pages)!