### PR TITLE
Adding OPHosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,7 @@ Table of Contents
   * [Versoly](https://versoly.com/) — SaaS focussed website builder - unlimited websites, 70+ blocks, 5 templates, custom CSS, favicon, SEO and forms. No custom domain.
   * [Qovery](https://www.qovery.com) — Qovery is the simplest way to deploy your full-stack apps on AWS, GCP and Azure. It is free web hosting for developers with Database, SSL, a global CDN, and auto deploys from Git.
   * [FlashDrive.io](https://flashdrive.io) - PaaS service similar to Heroku with a developer-centric approach and all inclusive features. Free tier for static assets, staging and developer apps.
+  * [OPHosting](https://ophosting.net/?utm_source=free-for-dev) - Free Webhosting for unlimited Projects.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Updated Terms of Services, removed fees. OPHosting is a partner of iFastNet (IFastNet LTD, UK).