### PR TITLE
travis-ci.org moved to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,6 @@ Table of Contents
   * [Squash Labs](https://www.squash.io/) — creates a VM for each branch and makes your app available from a unique URL, Unlimited public & private repos, Up to 2 GB VM Sizes.
   * [stackahoy.io](https://stackahoy.io) — 100% free. Unlimited deployments, branches and builds
   * [styleci.io](https://styleci.io/) — Public GitHub repositories only
-  * [travis-ci.com](https://travis-ci.com/) — [Free for public GitHub repositories](https://docs.travis-ci.com/user/billing-faq/#what-if-i-am-building-open-source)
   * [Mergify](https://mergify.io) — workflow automation and merge queue for GitHub — Free for public GitHub repositories
   * [Integromat](https://www.integromat.com) — Workflow automation tool which lets you connect apps and automate workflows using UI, it supports many apps and most popular APIs. Free for public GitHub repositories, and free tier with 100 Mb, 1000 Operations and 15 minutes of minimum interval.
 


### PR DESCRIPTION
open source projects have to manually apply for OSS Credits, see https://docs.travis-ci.com/user/billing-faq/#what-if-i-am-building-open-source