### PR TITLE
Added squadcast to the list of monitoring tools that have a free plan.

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ Table of Contents
   * [asayer.io](https://asayer.io/pricing.html) — Hosted version of openreplay, an open-source session replay (alternative to FullStory and LogRocket). Free 1k sessions/month with 14 days retention
   * [lean20.com](https://lean20.com/product/status/) - Public status pages for incident reporting. 100% free.
   * [instatus.com](https://instatus.com) - Get a beautiful status page in 10 seconds. Free forever with unlimited subs and unlimited teams.
+  * [Squadcast.com](https://squadcast.com) - Squadcast is an end-to-end incident management software that's designed to help you promote SRE best practices. Free forever plan available for upto 10 users.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Added squadcast.com to the list of monitoring tools. Squadcast has a free forever plan for up to 10 users.