### PR TITLE
Rename STUN heading to Tunnel, cleanup of section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Table of Contents
    * [Security and PKI](#security-and-pki)
    * [Source Code Repos](#source-code-repos)
    * [Storage and Media Processing](#storage-and-media-processing)
-   * [STUN, WebRTC, Web Socket Servers and Other Routers](#stun-webrtc-web-socket-servers-and-other-routers)
+   * [Tunneling, WebRTC, Web Socket Servers and Other Routers](#tunneling-webrtc-web-socket-servers-and-other-routers)
    * [Testing](#testing)
    * [Tools for Teams and Collaboration](#tools-for-teams-and-collaboration)
    * [Translation Management](#translation-management)

--- a/README.md
+++ b/README.md
@@ -1040,8 +1040,8 @@ Table of Contents
    * [conveyor.cloud](https://conveyor.cloud/) — Visual Studio extension to expose IIS Express to the local network or over a tunnel to a public URL.
    * [Hamachi](https://www.vpn.net/) — LogMeIn Hamachi is a hosted VPN service that lets you securely extend LAN-like networks to distributed teams with free plan allows unlimited networks with up to 5 peoples
    * [Radmin VPN](https://www.radmin-vpn.com/) - Connect multiple computers together via a VPN enabling LAN-like networks. Unlimited peers. (Hamachi alternative)
-   * [localhost.run](https://localhost.run/) — Instantly share your localhost environment! No download required. Run your app on port 8080 and then run this command and share the URL.
-   * [localtunnel](https://theboroer.github.io/localtunnel-www/) - Easily share a web service on your local development machine to a public internet URL without messing with DNS and firewall settings. Similar to Ngrok. In addition to the free hosted version, it is also [open source](https://github.com/localtunnel/localtunnel).
+   * [localhost.run](https://localhost.run/) — Expose locally running servers over a tunnel to a public URL.
+   * [localtunnel](https://theboroer.github.io/localtunnel-www/) - Expose locally running servers over a tunnel to a public URL. Free hosted version, and [open source](https://github.com/localtunnel/localtunnel).
    * [ngrok.com](https://ngrok.com/) — Expose locally running servers over a tunnel to a public URL.
    * [segment.com](https://segment.com/) — Hub to translate and route events to other third-party services. 100,000 events/month free
    * STUN Session Traversal of User Datagram Protocol [UDP] Through Network Address Translators [NATs])

--- a/README.md
+++ b/README.md
@@ -1035,7 +1035,7 @@ Table of Contents
 
 **[⬆ back to top](#table-of-contents)**
 
-## STUN, WebRTC, Web Socket Servers and Other Routers
+## Tunneling, WebRTC, Web Socket Servers and Other Routers
 
    * [conveyor.cloud](https://conveyor.cloud/) — Visual Studio extension to expose IIS Express to the local network or over a tunnel to a public URL.
    * [Hamachi](https://www.vpn.net/) — LogMeIn Hamachi is a hosted VPN service that lets you securely extend LAN-like networks to distributed teams with free plan allows unlimited networks with up to 5 peoples
@@ -1044,8 +1044,9 @@ Table of Contents
    * [localtunnel](https://theboroer.github.io/localtunnel-www/) - Easily share a web service on your local development machine to a public internet URL without messing with DNS and firewall settings. Similar to Ngrok. In addition to the free hosted version, it is also [open source](https://github.com/localtunnel/localtunnel).
    * [ngrok.com](https://ngrok.com/) — Expose locally running servers over a tunnel to a public URL.
    * [segment.com](https://segment.com/) — Hub to translate and route events to other third-party services. 100,000 events/month free
-   * [stun:global.stun.twilio.com:3478?transport=udp](stun:global.stun.twilio.com:3478?transport=udp) — Twilio STUN
-   * [stun:stun.l.google.com:19302](stun:stun.l.google.com:19302) — Google STUN
+   * STUN Session Traversal of User Datagram Protocol [UDP] Through Network Address Translators [NATs])
+     * Twilio STUN -- [stun:global.stun.twilio.com:3478?transport=udp](stun:global.stun.twilio.com:3478?transport=udp)
+     * Google STUN -- [stun:stun.l.google.com:19302](stun:stun.l.google.com:19302)   
    * [webhookrelay.com](https://webhookrelay.com) — Manage, debug, fan-out and proxy all your webhooks to public or internal (ie: localhost) destinations. Also, expose servers running in a private network over a tunnel by getting a public HTTP endpoint (`https://yoursubdomain.webrelay.io <----> http://localhost:8080`).
    * [Xirsys](https://www.xirsys.com) — Global network of STUN / TURN servers with a generous free tier.
    * [ZeroTier](https://www.zerotier.com) — FOSS managed virtual Ethernet as a service. Unlimited end-to-end encrypted networks of 100 clients on free plan. Clients for desktop/mobile/NA; web interface for configuration of custom routing rules and approval of new client nodes on private networks.

--- a/README.md
+++ b/README.md
@@ -1044,7 +1044,7 @@ Table of Contents
    * [ngrok.com](https://ngrok.com/) — Expose locally running servers over a tunnel to a public URL.
    * [Radmin VPN](https://www.radmin-vpn.com/) — Connect multiple computers together via a VPN enabling LAN-like networks. Unlimited peers. (Hamachi alternative)
    * [segment.com](https://segment.com/) — Hub to translate and route events to other third-party services. 100,000 events/month free
-   * STUN Session Traversal of User Datagram Protocol [UDP] Through Network Address Translators [NATs])
+   * [STUN](https://en.wikipedia.org/wiki/STUN) — Session Traversal of User Datagram Protocol [UDP] Through Network Address Translators [NATs])
      * Google STUN — [stun:stun.l.google.com:19302](stun:stun.l.google.com:19302)
      * Twilio STUN — [stun:global.stun.twilio.com:3478?transport=udp](stun:global.stun.twilio.com:3478?transport=udp)
    * [Tailscale](https://tailscale.com/) — Zero config VPN, using the open source WireGuard protocol. Installs on MacOS, iOS, Windows, Linux, and Android devices. Free plan for personal use with 20 devices.

--- a/README.md
+++ b/README.md
@@ -1039,18 +1039,18 @@ Table of Contents
 
    * [conveyor.cloud](https://conveyor.cloud/) — Visual Studio extension to expose IIS Express to the local network or over a tunnel to a public URL.
    * [Hamachi](https://www.vpn.net/) — LogMeIn Hamachi is a hosted VPN service that lets you securely extend LAN-like networks to distributed teams with free plan allows unlimited networks with up to 5 peoples
-   * [Radmin VPN](https://www.radmin-vpn.com/) - Connect multiple computers together via a VPN enabling LAN-like networks. Unlimited peers. (Hamachi alternative)
    * [localhost.run](https://localhost.run/) — Expose locally running servers over a tunnel to a public URL.
-   * [localtunnel](https://theboroer.github.io/localtunnel-www/) - Expose locally running servers over a tunnel to a public URL. Free hosted version, and [open source](https://github.com/localtunnel/localtunnel).
+   * [localtunnel](https://theboroer.github.io/localtunnel-www/) — Expose locally running servers over a tunnel to a public URL. Free hosted version, and [open source](https://github.com/localtunnel/localtunnel).
    * [ngrok.com](https://ngrok.com/) — Expose locally running servers over a tunnel to a public URL.
+   * [Radmin VPN](https://www.radmin-vpn.com/) — Connect multiple computers together via a VPN enabling LAN-like networks. Unlimited peers. (Hamachi alternative)
    * [segment.com](https://segment.com/) — Hub to translate and route events to other third-party services. 100,000 events/month free
    * STUN Session Traversal of User Datagram Protocol [UDP] Through Network Address Translators [NATs])
-     * Twilio STUN -- [stun:global.stun.twilio.com:3478?transport=udp](stun:global.stun.twilio.com:3478?transport=udp)
-     * Google STUN -- [stun:stun.l.google.com:19302](stun:stun.l.google.com:19302)   
+     * Google STUN — [stun:stun.l.google.com:19302](stun:stun.l.google.com:19302)
+     * Twilio STUN — [stun:global.stun.twilio.com:3478?transport=udp](stun:global.stun.twilio.com:3478?transport=udp)
+   * [Tailscale](https://tailscale.com/) — Zero config VPN, using the open source WireGuard protocol. Installs on MacOS, iOS, Windows, Linux, and Android devices. Free plan for personal use with 20 devices.
    * [webhookrelay.com](https://webhookrelay.com) — Manage, debug, fan-out and proxy all your webhooks to public or internal (ie: localhost) destinations. Also, expose servers running in a private network over a tunnel by getting a public HTTP endpoint (`https://yoursubdomain.webrelay.io <----> http://localhost:8080`).
    * [Xirsys](https://www.xirsys.com) — Global network of STUN / TURN servers with a generous free tier.
    * [ZeroTier](https://www.zerotier.com) — FOSS managed virtual Ethernet as a service. Unlimited end-to-end encrypted networks of 100 clients on free plan. Clients for desktop/mobile/NA; web interface for configuration of custom routing rules and approval of new client nodes on private networks.
-   * [Tailscale](https://tailscale.com/) — Zero config VPN, using the open source WireGuard protocol. Installs on MacOS, iOS, Windows, Linux, and Android devices. Free plan for personal use with 20 devices.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Changed heading for clarity. Defined STUN within section. Alphabetized section. Cleaned up some service descriptions. I have avoided the use of VPN nomenclature in favor of tunnel, so as to not confuse these server to server tunnels with client to server tunnels (what people commonly think of VPN).

Edited TOC to preserve anchor jump to section. Note, this breaks alphabetical organization of TOC; but this was already broken by a pattern of new sections being added to the bottom of TC regardless of alphabet. I.e. "Commenting Platforms" and "Browser Based hardware emulation".

I will look to doing a full alphabetical cleanup of TOC and section entries in a future PR.

I am grateful for any feedback on the structure of my commits and general git norms. I think I could have organized the commits better to set maintainer up for cherry-picking, if they desire to. I.e. if I was going to sort alphabetically, I should have committed that first, and then edited the entries, so maintainer could merge the sort, but ignore the section entry if they wanted to.