### PR TITLE
Added psono.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Table of Contents
   * [Nuclino](https://www.nuclino.com) - A lightweight and collaborative wiki for all your team's knowledge, docs, and notes. Free plan with all essential features, up to 50 items, 5GB total storage.
   * [PageShare.dev](https://www.pageshare.dev) - Adds visual reviews capabilities into GitHub Pull Requests with no need to deploy websites. Free for up to 10 pages each month and 100MB of storage in total.
   * [Pendulums](https://pendulums.io/) - Pendulums is a free time tracking tool which helps you to manage your time in a better manner with an easy to use interface and useful statistics.
+  * [Psono](https://psono.com/) - Password manager for teams to securely store and share passwords and other secrets encrypted. Supports Windows, Linux, Mac, iOS and Android.
   * [Raindrop.io](https://raindrop.io) - Private and secure bookmarking app for macOS, Windows, Android, iOS and Web. Free Unlimited Bookmarks and Collaboration.
   * [element.io](https://element.io/) — A decentralized and open source communication tool built on Matrix. Group chats, direct messaging, encrypted file transfers, voice and video chats, and easy integration with other services.
   * [Rocket.Chat](https://rocket.chat/) - Shared inbox for teams, secure, unlimited and open source.


### PR DESCRIPTION
Psono is a password manager for teams. It's community edition is completely free and the enterprise edition is free for up to 10 users. There is also a free hosted version for those who don't want to host Psono themself available under https://psono.pw