### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       search: ['/'],
       darklightTheme: {
         siteFont : 'Source Sans Pro, Helvetica Neue',
+        defaultTheme : 'light',
         codeFontFamily : 'Roboto Mono, Monaco, courier, monospace',
         bodyFontSize: '15px',
       }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta charset="UTF-8">
   <title>Free for developers</title>
-  <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/vue.css">
   <link 
       rel="stylesheet"
       href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
@@ -40,8 +40,8 @@
       }
     }
   </script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
   <script 
       src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
       type="text/javascript">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
   <meta charset="UTF-8">
   <title>Free for developers</title>
   <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
+  <link 
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+      title="docsify-darklight-theme"
+      type="text/css"
+  />
   <link rel="icon" href="logo.webp" type="image/gif" sizes="16x16">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-DLYKZXPL9J"></script>
@@ -25,11 +31,20 @@
     window.$docsify = {
       name: 'Free for developers',
       repo: 'ripienaar/free-for-dev',
-      search: ['/']
+      search: ['/'],
+      darklightTheme: {
+        siteFont : 'Source Sans Pro, Helvetica Neue',
+        codeFontFamily : 'Roboto Mono, Monaco, courier, monospace',
+        bodyFontSize: '15px',
+      }
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+  <script 
+      src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+      type="text/javascript">
+  </script>
   <style>
     a[href="#/?id=%f0%9f%aa%90-deta-the-free-cloud-for-hackers"] {
       color: rgb(233, 105, 0) !important;


### PR DESCRIPTION
## Summary

I like browsing this site but sometimes the light theme is too harsh.

Add dark/light theme toggle from here: https://github.com/boopathikumar018/docsify-darklight-theme

According to the [docs](https://docsify-darklight-theme.boopathikumar.me/#/configuration?id=default-browser-theme-detection#/configuration?id=default-browser-theme-detection#/configuration?id=default-browser-theme-detection) it should detect the browser's default theme, and falls back to light theme by default on unsupported browsers.

## Screenshots

![image](https://user-images.githubusercontent.com/13279967/152631519-ef257e9f-fc68-4e99-b9ca-94fb59c03959.png)

![image](https://user-images.githubusercontent.com/13279967/152631513-6ebc2d70-dc10-4378-8e47-2c0f53ede1e2.png)
