### PR TITLE
modify ide.cs50 to code.cs50

### DIFF
--- a/README.md
+++ b/README.md
@@ -1377,7 +1377,7 @@ Table of Contents
    * [codiga.io](https://codiga.io/) — Coding Assistant that lets you search, define and reuse code snippets directly in your IDE. Free for individual and small organizations.
    * [codesnip.com.br](https://codesnip.com.br) — Simple code snippets manager with categories, search and tags. free and unlimited.
    * [cocalc.com](https://cocalc.com/) — (formerly SageMathCloud at cloud.sagemath.com) — Collaborative calculation in the cloud. Browser access to full Ubuntu with built-in collaboration and lots of free software for mathematics, science, data science, preinstalled: Python, LaTeX, Jupyter Notebooks, SageMath, scikitlearn, etc.
-   * [ide.cs50.io](https://ide.cs50.io/) - A free IDE powered by AWS Cloud9 by Harvard University.
+   * [code.cs50.io](https://code.cs50.io/) - Visual Studio Code for CS50 is a web app at code.cs50.io that adapts GitHub Codespaces for students and teachers.
    * [codepen.io](https://codepen.io/) — CodePen is a playground for the front end side of the web.
    * [codesandbox.io](https://codesandbox.io/) — Online Playground for React, Vue, Angular, Preact and more.
    * [Components.studio](https://webcomponents.dev/) - Code components in isolation, visualize them in stories, test them and publish them on npm.


### PR DESCRIPTION
Cs50 has enabled their new ide.

> We are sunsetting CS50 IDE and [VS Code for CS50](https://code.cs50.io/) is our new integrated development environment. Please check out this [documentation](https://cs50.harvard.edu/x/2022/new/#how-to-copy-files-from-cs50-ide-to-your-cs50-codespace) on migrating your files from CS50 IDE to your Codespace.