### PR TITLE
Add Httpic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1549,6 +1549,7 @@ Table of Contents
   * [screenshotmachine.com](https://www.screenshotmachine.com/) — Capture 100 snapshots/month, png, gif and jpg, including full-length captures, not only home page
   * [PhantomJsCloud](https://PhantomJsCloud.com) — Browser automation and page rendering.  Free Tier offers up to 500 pages/day.  Free Tier since 2017.
   * [Webshrinker.com](https://webshrinker.com) — Web Shrinker provides web site screenshot and domain intelligence API services. Free 100 requests/month.
+  * [Httpic.com](https://httpic.com) — Turn any website into jpg, png or pdf. Capture full page screenshots, adjust viewport, inject custom code. Free tier at 150 images / month.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Httpic lets you capture up to 150 free screenshots, on top of Google Chrome and Serverless. Free tier allows pretty much everything the platform has to offer. 

Thanks for creating such an useful list!