### PR TITLE
Goodbye Octopus :'(

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,6 @@ Table of Contents
   * [drone](https://cloud.drone.io/) - Drone Cloud enables developers to run Continuous Delivery pipelines across multiple architectures - including x86 and Arm (both 32 bit and 64 bit) - all in one place
   * [LayerCI](https://layerci.com) — CI for full stack projects. 1 full stack preview environment with 5GB memory & 3 CPUs .
   * [ligurio/awesome-ci](https://github.com/ligurio/awesome-ci) — Comparison of Continuous Integration services
-  * [Octopus Deploy](https://octopus.com) - Automated deployment and release-management. Free for <= 10 deployment targets.
   * [scalr.com](https://scalr.com/) - Remote state & operations backend for Terraform with full CLI support, integration with OPA and a hierarchical configuration model. Free up to 5 users.
   * [semaphoreci.com](https://semaphoreci.com/) — Free for Open Source, 100 private builds per month
   * [Squash Labs](https://www.squash.io/) — creates a VM for each branch and makes your app available from a unique URL, Unlimited public & private repos, Up to 2 GB VM Sizes.


### PR DESCRIPTION
Octopus removed their free tier... there's now a $10/mo [community tier](https://octopus.com/pricing/faq#are-there-any-free-or-low-cost-versions-of-octopus-deploy) that has more limits that the old free tier.

I think we should delete it because the only free version now is the self hosted community version.