### PR TITLE
docs: add ory free for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Table of Contents
   * [onelogin.com](https://www.onelogin.com/) — Identity as a Service (IDaaS), Single Sign-On Identity Provider, Cloud SSO IdP, 3 company apps and 5 personal apps, unlimited users
   * [Operous](https://operous.dev/) — Cloud instance testing tool with a comprehensive and automated set of test-suites of best practices, performance, and security. Free tier offers 100 testing minutes, 10 Test Suites, and up to 5 instances to 1 user.
   * [opswat.com](https://www.opswat.com/) — Security Monitoring of computers, devices, applications, configurations,... Free 25 users and 30 days history users.
+  * [Ory](https://ory.sh/) - AuthN/AuthZ/OAuth2.0/Zero Trust managed security platform. Forever free developer accounts with all security features, unlimited team members, 200 daily active users, and 25k/mo permission checks.
   * [pyup.io](https://pyup.io) — Monitor Python dependencies for security vulnerabilities and update them automatically. Free for one private project, unlimited projects for open source.
   * [qualys.com](https://www.qualys.com/community-edition) — Find web app vulnerabilities, audit for OWASP Risks
   * [reCAPTCHAMe](https://recaptchame.com/) — free reCAPTCHA and hCAPTCHA backend service. No Server-Side coding needed. Works for static websites.


### PR DESCRIPTION
### Free SaaS Offering Submission

You can self-host Ory but they also offer a managed SaaS version https://console.ory.sh/.
Let me know if there is something unclear in the description.
The developer accounts will be forever free and include all security features. There are production limits on the dev accounts which I outlined in the submission.

### New Submission Check List

Please ensure your submission ticks all of these boxes:

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list

