### PR TITLE
Add Memfault to the "Crash and Exception Handling" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,7 @@ Table of Contents
   * [exceptionless](https://exceptionless.com) — Real-time error, feature, log reporting and more. Free for 3k events per month/1 user. Open source and easy to self-host for unlimited use.
   * [GlitchTip](https://glitchtip.com/) — Simple, open source error tracking. Compatible with open-source Sentry SDKs. 1000 events per month for free, or can self-host with no limits
   * [honeybadger.io](https://www.honeybadger.io) - Exception, uptime, and cron monitoring. Free for small teams and open-source projects (12,000 errors/month).
+  * [memfault.com](https://memfault.com) — Cloud platform for device observability and debugging. 100 devices free for [Nordic](https://app.memfault.com/register-nordic), [NXP](https://app.memfault.com/register-nxp), and [Laird](https://app.memfault.com/register-laird) devices.
   * [rollbar.com](https://rollbar.com/) — Exception and error monitoring, free plan with 5,000 errors/month, unlimited users, 30 days retention
   * [sentry.io](https://sentry.io/) — Sentry tracks app exceptions in real-time, has a small free plan. Free for 5k errors per month/ 1 user, unrestricted use if self-hosted
 


### PR DESCRIPTION
Hi there! [Memfault](https://memfault.com/) offers a free-forever tier of 100 devices to projects using certain brands of chips. This PR adds it to the Crash and Exception Handling section.

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list