### PR TITLE
Removed tebi.io from  IaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,7 +1106,6 @@ Table of Contents
   * [fosshost.org](https://fosshost.org/) - Free open source hosting VPS, web, storage and mirror hosting.
   * [scaleway](https://www.scaleway.com/en/object-storage/) — S3-Compatible Object Storage. Free 75 GB storage and external outgoing traffic.
   * [Storj](https://storj.io/) — Decentralised Private Cloud Storage for Apps and Developers. Free plan provides 3 Projects, 50 GB storage per project/month , 50 GB bandwidth per project/month.
-  * [Tebi](https://tebi.io/) - S3 compatibility object storage.Free 25 GB storage and 250GB outbound transfer.
   * [Idrive e2](https://www.idrive.com/e2/) - S3 compatibility object storage. 10 GB free storage and 10 GB download bandwidth per month.
   * [C2 Object Storage](https://c2.synology.com/en-us/pricing/object-storage) - S3 compatibility object storage. 15 GB free storage and 15 GB download per month.
 


### PR DESCRIPTION
### Free SaaS Offering Submission

Thank you for contributing to this list. This list is for **SaaS**
services that offer a **free tier** to help developers evaluate and
build something that users can later use and get support for.

The focus of this list is quite broad but we try to keep things
limited to that which infrastructure developers, like DevOps Practitioners,
would find useful.

We do not anymore accept cPanel like PHP+MySQL hosting services.

### New Submission Check List

<!-- Only for new submissions -->

Please ensure your submission ticks all of these boxes:

 - [ ] This is Software as a Service not self hosted
 - [ ] It has a free tier not just a free trial
 - [ ] The submission mentions what is free
 - [ ] The submission is not already present in the list

### Thank You

This list is the result of more than a thousand people contributing
to make something useful, we appreciate your efforts.

---   
---  
tebi.io has now  a free tier + pay-as-you-go as basic option. It expires in 14 days.  After that period data becomes read-only, and requires card (no prepaid accepted)  to go on.  I think it should be removed from this list.

[https://tebi.io/#faq](https://tebi.io/#faq)  

![tebi io-1](https://user-images.githubusercontent.com/108318349/181270673-d02baf68-9364-483a-af72-25c3619605f1.png)

