### PR TITLE
99inbound and formkeep merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,11 +887,11 @@ Table of Contents
 
 ## Forms
   * [FabForm](https://fabform.io/) - Form backend platform for smart developers. Free plan allows 250 form submissions per month. Friendly modern GUI. Integrates with Google Sheets, Airtable, Slack, Email and others.
-  * [99inbound.com](https://www.99inbound.com/) - Build forms and share them online. Get an email or Slack message for each submission. Free plan has 2 forms, 100 entries per month, basic email & Slack.
   * [Form.taxi](https://form.taxi/) — Endpoint for HTML forms submissions. With notifications, spam blocker and GDPR-compliant data processing. Free plan for basic usage.
   * [Formcake.com](https://formcake.com) - Form backend for devs, free plan allows unlimited forms, 100 submissions, Zapier integration. No libraries or dependencies required.
   * [Formcarry.com](https://formcarry.com) - HTTP POST Form endpoint, Free plan allows 100 submissions per month.
   * [formingo.co](https://www.formingo.co/)- Easy HTML forms for static websites, get started for free without registering an account. Free plan allows 500 submissions per month, customizable reply-to email address.
+  * [FormKeep.com](https://www.formkeep.com/) - Unlimited forms with 50 submissions per month, spam protection, email notification and a drag and drop designer that can export HTML. Additional features include custom field rules, teams and integrations to Google Sheets, Slack, ActiveCampaign and Zapier.
   * [formlets.com](https://formlets.com/) — Online forms, unlimited single page forms/month, 100 submissions/month, email notifications.
   * [formrocket.me](https://www.formrocket.me) - HTML forms made easy, unlimited forms & responses. Comes with Discord notifications and more.
   * [formspark.io](https://formspark.io/) -  Form to Email service, free plan allows unlimited forms, 250 submissions per month, support by Customer assistance team.


### PR DESCRIPTION
Hi - I removed 99inbound and added FormKeep as we own both businesses and recently decided to only accept new accounts on FormKeep. 


### Free SaaS Offering Submission

Thank you for contributing to this list. This list is for **SaaS**
services that offer a **free tier** to help developers evaluate and
build something that users can later use and get support for.

The focus of this list is quite broad but we try to keep things
limited to that which infrastructure developers, like DevOps Practitioners,
would find useful.

We do not anymore accept cPanel like PHP+MySQL hosting services.

### New Submission Check List

<!-- Only for new submissions -->

Please ensure your submission ticks all of these boxes:

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list

### Thank You

This list is the result of more than a thousand people contributing
to make something useful, we appreciate your efforts.
