### PR TITLE
Update humio logging limit per day

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Table of Contents
 ## Log Management
 
   * [bugfender.com](https://bugfender.com/) — Free up to 100k log lines/day with 24 hours retention
-  * [humio.com](https://www.humio.com/) — Free up to 2 GB/day with 7 days retention
+  * [humio.com](https://www.humio.com/) — Free up to 16 GB/day with 7 days retention
   * [logdna.com](https://logdna.com) - Free for a single user, no retention, unlimited hosts and sources
   * [logentries.com](https://logentries.com/) — Free up to 5 GB/month with 7 days retention
   * [loggly.com](https://www.loggly.com/) — Free for a single user, 200MB/day with 7 days retention


### PR DESCRIPTION
Changing the 2GB to 16GB that is now included with the free account.