### PR TITLE
Removed Yandex.Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,7 +1073,6 @@ Table of Contents
   * [pointhq.com](https://pointhq.com/developer) — Free DNS hosting on Heroku.
   * [sslip.io](https://sslip.io/) — Free DNS service that when queried with a hostname with an embedded IP address returns that IP address.
   * [web.gratisdns.dk](https://web.gratisdns.dk/domaener/dns/) — Free DNS hosting.
-  * [Yandex.Connect](https://connect.yandex.com/pdd/) — Free email and DNS hosting for up to 1,000 users
   * [zilore.com](https://zilore.com/en/dns) — Free DNS hosting.
   * [zoneedit.com](https://www.zoneedit.com/free-dns/) — Free DNS hosting with Dynamic DNS Support.
   * [zonewatcher.com](https://zonewatcher.com) — Automatic backups and DNS change monitoring. 1 domain free


### PR DESCRIPTION
During 2021, Yandex.Connect was reorganised to two separate platforms - Yandex.360 and Yandex.Cloud. 

Mentioned "Free email and DNS hosting for up to 1,000 users" was moved to Yandex.360, but in December 2021 Yandex dropped free service, so it's not free anymore for new users - https://360.yandex.com/business/tariff/