### PR TITLE
Adding Appwrite to BaaS and DBaaS lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Table of Contents
 ## Messaging and Streaming
 
   * [Ably](https://www.ably.com/) - Realtime messaging service with presence, persistence and guaranteed delivery. Free plan includes 3m messages per month, 100 peak connections and 100 peak channels.
+  * [Appwrite](https://appwrite.io/) - APIs for Databases, Auth & Users, Storage, Functions, GEO & Localization and API creation. Free, Open-Source and self-hosted, cloud version is under development and it will have a free tier.
   * [cloudamqp.com](https://www.cloudamqp.com/) — RabbitMQ as a Service. Little Lemur plan: max 1 million messages/month, max 20 concurrent connections, max 100 queues, max 10,000 queued messages, multiple nodes in different AZ's
   * [connectycube.com](https://connectycube.com) - Unlimited chat messages, p2p voice & video calls, files attachments and push notifications. Free for apps up to 20K MAU.
   * [courier.com](https://www.courier.com/) — Single API for push, in-app, email, chat, SMS, and other messaging channels with template management and other features. Free plan includes 10,000 messages/mo.
@@ -1119,6 +1120,7 @@ Table of Contents
 ## DBaaS
 
    * [airtable.com](https://airtable.com/) — Looks like a spreadsheet, but it's a relational database, unlimited bases, 1,200 rows/base and 1,000 API requests/month
+   * [Appwrite](https://appwrite.io/) - APIs for Databases, Auth & Users, Storage, Functions, GEO & Localization and API creation. Free, Open-Source and self-hosted, cloud version is under development and it will have a free tier.
    * [Astra](https://www.datastax.com/products/datastax-astra/) — Cloud Native Cassandra as a Service with [80GB free tier](https://www.datastax.com/products/datastax-astra/pricing)
    * [bit.io](https://bit.io) — Managed PostgreSQL database service. 1 database, 10GB storage, 1 CPU and 1GB Memory (burst).
    * [cloudamqp.com](https://www.cloudamqp.com/) — RabbitMQ as a Service, up to 1M messages/month and 20 connections free


### PR DESCRIPTION
<!--
### Free SaaS Offering Submission

Thank you for contributing to this list. This list is for **SaaS**
services that offer a **free tier** to help developers evaluate and
build something that users can later use and get support for.

The focus of this list is quite broad but we try to keep things
limited to that which infrastructure developers, like DevOps Practitioners,
would find useful.

This list is the result of more than a thousand people contributing
to make something useful, we appreciate your efforts.

NOTES:
  * We do not anymore accept cPanel like PHP+MySQL hosting services.
-->

### Description

Adding [Appwrite](https://appwrite.io/) to the list, although it is a self-hosted BaaS, they are open-source and soon they will launch the cloud version.  I think that it would add value to the list since the deployment is very easy.


### New Submission Check List

<!-- Only for new submissions -->

Please ensure your submission ticks all of these boxes:

 - [ ] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list
