### PR TITLE
PaaS: add Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,6 +957,7 @@ Table of Contents
   * [encore.dev](https://encore.dev/) — Backend framework using static analysis to provide automatic infrastructure, boilerplate free code, and more. Includes free cloud hosting for hobby projects.
   * [gigalixir.com](https://gigalixir.com/) - Gigalixir provide 1 free instance that never sleeps, and free-tier PostgreSQL database limited to 2 connections, 10, 000 rows and no backups, for Elixir/Phoenix apps.
   * [Glitch](https://glitch.com/) — Free public hosting with features such as code sharing and real-time collaboration. Free plan has 1000 hours/month limit.
+  * [Heroku](https://heroku.com/free) Build apps for free on Heroku
   * [Krucible](https://usekrucible.com) — Krucible is a platform for creating Kubernetes clusters for testing and development. Free tier accounts come with 25 cluster-hours per month.
   * [Mendix](https://www.mendix.com/) — Rapid Application Development for Enterprises, unlimited number of free sandbox environments supporting unlimited users, 0.5 GB storage and 1 GB RAM per app. Also Studio and Studio Pro IDEs are allowed in free tier.
   * [m3o.com](https://m3o.com) - A cloud platform for API services development. M3O is a fully managed Micro as a Service offering focusing on Go microservices development in the Cloud. Free tier provides enough to run 5 services and collaborate with others.


### PR DESCRIPTION
<!--
### Free SaaS Offering Submission

Thank you for contributing to this list. This list is for **SaaS**
services that offer a **free tier** to help developers evaluate and
build something that users can later use and get support for.

The focus of this list is quite broad but we try to keep things
limited to that which infrastructure developers, like DevOps Practitioners,
would find useful.

This list is the result of more than a thousand people contributing
to make something useful, we appreciate your efforts.

NOTES:
  * We do not anymore accept cPanel like PHP+MySQL hosting services.
-->

### New Submission Check List

<!-- Only for new submissions -->

Please ensure your submission ticks all of these boxes:

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list
 - [x] The service has contact details of those running it and a privacy policy
