### PR TITLE
Adds storage limit for the GitHub Codespaces free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Table of Contents
   * [GitGud](https://gitgud.io) — Unlimited private and public repositories. Free forever. Powered by GitLab & Sapphire. CI/CD not provided.
   * [GitHub](https://github.com/) — Unlimited public repositories and unlimited private repositories (with unlimited collaborators). Apart from this some other free services(there are much more but we list the main ones here) provided are :
        - [CI/CD](https://github.com/features/actions)(Free for Public Repos, 2000 min/month for private repos free)
-       - [Codespaces](https://github.com/codespaces) - Development environments that are hosted in the cloud. 120-core hours available for free every month.
+       - [Codespaces](https://github.com/codespaces) - Development environments that are hosted in the cloud. 120-core hours and 15 GB codespaces storage available for free every month.
        - [Static Website Hosting](https://pages.github.com) (Free for Public Repos)
        - [Package Hosting & Container Registry](https://github.com/features/packages) (Free for public repos,500 MB storage & 1GB bandwidth outside CI/CD free for private repos)
        - Project Management & Issue Tracking.


### PR DESCRIPTION
<!--
### Free SaaS Offering Submission

Thank you for contributing to this list. This list is for **SaaS**
services that offer a **free tier** to help developers evaluate and
build something that users can later use and get support for.

The focus of this list is quite broad but we try to keep things
limited to that which infrastructure developers, like DevOps Practitioners,
would find useful.

This list is the result of more than a thousand people contributing
to make something useful, we appreciate your efforts.

### Code of Conduct

We are not here to argue with you. If you are argumentative, abusive,
lie or missrepresent your service or are otherwise anti-social we will
block you.

### Services we do not accept

  * cPanel like PHP+MySQL hosting services.
  * Free dns services that are generic frontends to cloudflare or similar
  * Services that are verbatim copy pastes of others while adding no value

-->

### New Submission Check List

<!-- Only for new submissions -->

Not a new submission. Just an edit.

Please ensure your submission ticks all of these boxes:

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list
 - [x] The service has contact details of those running it and a privacy policy

Currently the list does not mention that Codespaces have a storage limit on the free tier. This PR fixes the same.
