### PR TITLE
Beampipe.io added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1498,6 +1498,7 @@ Table of Contents
    * [PostHog](https://posthog.com) - Full Product Analytics suite free for up to 1m tracked events per month
    * [Uptrace](https://uptrace.dev) - Distributed Tracing Tool that helps developers pinpoint failures and find performance bottlenecks. Has a free plan, offers a free Personal subscription for open source projects, and has an open source version.
    * [Microsoft Clarity](https://clarity.microsoft.com/) - Clarity is a free, easy-to-use tool that captures how real people actually use your site.
+   * [Beampipe.io](https://beampipe.io) - Beampipe is simple, privacy-focussed web analytics. free for up to 5 domains & 10k monthly page views.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Beampipe.io added at Analytics, Events and Statistics

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list
 - [x] The service has contact details of those running it and a privacy policy
