### PR TITLE
Adjust free block volume amount for Oracle Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Table of Contents
 
   * [Oracle Cloud](https://www.oracle.com/cloud/)
     * Compute - 2 x64-based with 1 GB RAM each, 4 Arm-based Ampere A1 cores and 24 GB of memory usable as one VM or up to 4 VMs
-    * Block Volume - 4 volumes, 200 GB total (used for compute)
+    * Block Volume - 2 volumes, 200 GB total (used for compute)
     * Object Storage - 10 GB
     * Load balancer - 1 instance with 10 Mbps
     * Databases - 2 DBs, 20 GB each


### PR DESCRIPTION
Oracle Cloud reduced the amount of free block volumes from 4 to 2.

<!--
### Free SaaS Offering Submission

Thank you for contributing to this list. This list is for **SaaS**
services that offer a **free tier** to help developers evaluate and
build something that users can later use and get support for.

The focus of this list is quite broad but we try to keep things
limited to that which infrastructure developers, like DevOps Practitioners,
would find useful.

This list is the result of more than a thousand people contributing
to make something useful, we appreciate your efforts.

### Code of Conduct

We are not here to argue with you. If you are argumentative, abusive,
lie or missrepresent your service or are otherwise anti-social we will
block you.

### Services we do not accept

  * cPanel like PHP+MySQL hosting services.
  * Free dns services that are generic frontends to cloudflare or similar
  * Services that are verbatim copy pastes of others while adding no value

-->

### New Submission Check List

<!-- Only for new submissions -->

Please ensure your submission ticks all of these boxes:

 - [x] This is Software as a Service not self hosted
 - [x] It has a free tier not just a free trial
 - [x] The submission mentions what is free
 - [x] The submission is not already present in the list
 - [x] The service has contact details of those running it and a privacy policy
