### PR TITLE
Remove Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1425,7 +1425,6 @@ Table of Contents
    * [Android Studio](https://d.android.com/studio) — Android Studio provides the fastest tools for building apps on every type of Android device. Open Source IDE, free for everyone and the best to develop Android apps. Available for Windows,Mac,Linux and even ChromeOS!
    * [Apache Netbeans](https://netbeans.apache.org/) — Development Environment, Tooling Platform and Application Framework.
    * [apiary.io](https://apiary.io/) — Collaborative design API with instant API mock and generated documentation (Free for unlimited API blueprints and unlimited user with one admin account and hosted documentation).
-   * [Atom](https://atom.io/) - Atom is a hackable text editor built on Electron.
    * [Binder](https://mybinder.org/) - Turn a Git repo into a collection of interactive notebooks. It is a free, public service.
    * [BlueJ](https://bluej.org) — A free Java Development Environment designed for beginners, used by millions worldwide. Powered by Oracle & simple GUI to help beginners.
    * [Bootify.io](https://bootify.io/) - Spring Boot app generator with custom database and REST API.


### PR DESCRIPTION
Atom was killed by GitHub on December 15, 2022

https://github.com/atom/atom/releases/tag/v1.63.1
https://github.blog/2022-06-08-sunsetting-atom