### PR TITLE
Remove ligurio/awesome-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,6 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [deployhq.com](https://www.deployhq.com/) — 1 project with 10 daily deployments (30 build minutes/month)
   * [drone](https://cloud.drone.io/) - Drone Cloud enables developers to run Continuous Delivery pipelines across multiple architectures - including x86 and Arm (both 32 bit and 64 bit) - all in one place
   * [LayerCI](https://layerci.com) — CI for full stack projects. 1 full stack preview environment with 5GB memory & 3 CPUs .
-  * [ligurio/awesome-ci](https://github.com/ligurio/awesome-ci) — Comparison of Continuous Integration services
   * [scalr.com](https://scalr.com/) - Remote state & operations backend for Terraform with full CLI support, integration with OPA and a hierarchical configuration model. Free up to 5 users.
   * [semaphoreci.com](https://semaphoreci.com/) — Free for Open Source, 100 private builds per month
   * [Squash Labs](https://www.squash.io/) — creates a VM for each branch and makes your app available from a unique URL, Unlimited public & private repos, Up to 2 GB VM Sizes.


### PR DESCRIPTION
Remove ligurio/awesome-ci form the CI/CD list, because it's a list and not a service.

<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [ ] This is Software as a Service not self hosted
 * [ ] It has a free tier not just a free trial
 * [ ] The submission mentions what is free
 * [ ] The submission is not already present in the list
 * [ ] The service has contact details of those running it and a privacy policy
