### PR TITLE
Remove unscan.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,6 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [Svix](https://www.svix.com/) - Webhooks as a Service. Send up to 50,000 messages/month for free.
   * [TinyMCE](https://www.tiny.cloud) - rich text editing API. Core features free for unlimited usage.
   * [Unixtime](https://unixtime.co.za) - Free API to convert Unixtime to DateTime and vice versa.
-  * [unscan](https://unscan.co) - Free API to scan images for NSFW and files for malware. 100 requests per second.
   * [Webhook.site](https://webhook.site) - Easily test HTTP webhooks with this handy tool that displays requests instantly.
   * [Webhook Store](https://www.openwebhook.io) - Tool for storing third party webhooks and debug them on localhost (ngrok style). Open source and self-hostable. Free personal domain *username*.github.webhook.store, free public domains *anything*.webhook.store.
   * [Weights & Biases](https://wandb.ai) — The developer-first MLOps platform. Build better models faster with experiment tracking, dataset versioning, and model management. Free tier for personal projects only, with 100 GB of storage included.


### PR DESCRIPTION
Domain expired, their [npm package](https://www.npmjs.com/package/unscan) marked as deprecated.
