### PR TITLE
add www. to the Descope url

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [Authress](https://authress.io/) — Authentication login and access control, unlimited identity providers for any project. Facebook, Google, Twitter and more. First 1000 API calls are free.
   * [Authy](https://authy.com) - Two-factor authentication (2FA) on multiple devices, with backups. Drop-in replacement for Google Authenticator. Free for up to 100 successful authentications.
   * [Clerk.dev](https://clerk.dev/) — User management, auth, 2FA/MFA with prebuilt UI components. Free up to 500 monthly active users.
-  * [Descope](https://descope.com/) — Highly customizable AuthN flows, has both a no-code and API/SDK approach, Free 7,500 active users/month, 50 tenants (up to 5 SAML/SSO tenants).
+  * [Descope](https://www.descope.com/) — Highly customizable AuthN flows, has both a no-code and API/SDK approach, Free 7,500 active users/month, 50 tenants (up to 5 SAML/SSO tenants).
   * [duo.com](https://duo.com/) — Two-factor authentication (2FA) for website or app. Free for 10 users, all authentication methods, unlimited, integrations, hardware tokens.
   * [Jumpcloud](https://jumpcloud.com/) — Provides directory as a service similar to Azure AD, user management, single sign-on, and RADIUS authentication. Free for up to 10 users.
   * [logintc.com](https://www.logintc.com/) — Two-factor authentication (2FA) by push notifications, free for 10 users, VPN, Websites and SSH


### PR DESCRIPTION
small fix for the url, while httos://descope.com is valid, it's a bit better to use https://www.descope.com/

<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy
