### PR TITLE
feat: add is-a.engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [eu.org](https://nic.eu.org) — Free eu.org domain. Request is usually approved in 14 days.
   * [js.org](https://js.org) - Free js.org subdomains for GitHub Pages for the JavaScript community.
   * [js.cool](https://github.com/willin/js.cool) - Free js.cool subdomains for GitHub Pages and Vercel.
+  * [is-a.engineer](https://github.com/is-a-engineer/is-a.engineer) - Free is-a.engineer subdomain for developers/engineers.
   * [pp.ua](https://nic.ua/) — Free pp.ua subdomains.
   * [thedev.id](https://thedev.id) — A free thedev.id subdomain for developers.
   * [is-a.dev](https://www.is-a.dev/) — Free is-a.dev subdomain for developers.


### PR DESCRIPTION
Hey, adding [is-a.engineer](https://github.com/is-a-engineer/is-a.engineer) to the list. Hopefully it's a useful resource for those needing a subdomain. Not sure if it fell under the "dns that is a frontend to cloudflare" bullet point, as that was somewhat unclear.

 * [X] This is Software as a Service not self hosted
 * [X] It has a free tier not just a free trial
 * [X] The submission mentions what is free
 * [X] The submission is not already present in the list
 * [X] The service has contact details of those running it and a privacy policy
