### PR TITLE
Added Remark42 to Commenting Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1628,6 +1628,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [GraphComment](https://graphcomment.com/) - GraphComment is a comments platform that helps you build an active community from website’s audience.
   * [Utterances](https://utteranc.es/) - A lightweight comments widget built on GitHub issues. Use GitHub issues for blog comments, wiki pages and more!
   * [Disqus](https://disqus.com/) - Disqus is a networked community platform used by hundreds of thousands of sites all over the web.
+  * [Remark42](https://remark42.com/) - Privacy-focused lightweight commenting engine
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Added [Remark42](https://remark42.com/) to Commenting Platforms

[github](https://github.com/umputun/remark42)

<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [ ] This is Software as a Service not self hosted
 * [ ] It has a free tier not just a free trial
 * [ ] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy
