### PR TITLE
Bring Back VistaPanel Hosts and Clarify their Authenticity as Non-Fake cPanel Hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,8 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [DuckDocs](https://duckdocs.com) - Markdown-powered documentation hosting, sort of like a hosted Docusaurus. Free for 10 pages per site.
   * [Fenix Web Server](https://preview.fenixwebserver.com) - A developer desktop app for hosting sites locally and sharing them publically (in realtime). Work however you like, using its beautiful user interface, API, and/or CLI.
   * [Free Hosting](https://freehostingnoads.net/) — Free Hosting With PHP 5, Perl, CGI, MySQL, FTP, File Manager, POP E-Mail, free sub-domains, free domain hosting, DNS Zone Editor, Web Site Statistics, FREE Online Support and many more features not offered by other free hosts.
+  * [InfinityFree](https://infinityfree.net/) — Free Hosting With PHP 7.4, MySQL, FTP, File Manager,  free sub-domains, free domain hosting, and many more features not offered by other free hosts.
+
   * [Freehostia](https://www.freehostia.com) — FreeHostia offers free hosting services incl. an industry-best Control Panel & a 1-click installation of 50+ free apps. Instant setup. No forced ads.
   * [Neocities](https://neocities.org) — Static, 1 GB free storage with 200 GB Bandwidth.
   * [Netlify](https://www.netlify.com/) — Builds, deploy and hosts static site/app free for, 100 GB data and 100 GB/month bandwidth.


### PR DESCRIPTION
Recently, VistaPanel hosts have been removed from the list of providers on Free-for-Dev, raising concerns among developers who have been using this hosting service. This issue aims to address the removal of VistaPanel hosts from the platform and clarify their authenticity as non-fake cPanel hosts.

Background:
VistaPanel is a web hosting control panel that has been providing free hosting services to developers for several years. It offers a user-friendly interface with features similar to cPanel, making it a popular choice among developers, particularly those working on small projects or personal websites.

Issue Details:

Removal of VistaPanel hosts: The sudden removal of VistaPanel hosts from the Free-for-Dev platform has left many developers puzzled and concerned. These hosts have been a reliable option for developers who require basic hosting functionalities without the need for advanced features provided by premium hosting services.

Authenticity concerns: It is important to note that VistaPanel hosts are NOT fake cPanel hosts. While cPanel is a widely recognized and powerful hosting control panel, VistaPanel is a separate, standalone control panel designed to provide a simplified hosting experience. The removal of VistaPanel hosts from Free-for-Dev may have inadvertently given the impression that they were illegitimate or fake.

Value for developers: VistaPanel hosts have been a valuable resource for developers who are just starting out or have limited budgets. They provide an accessible platform for experimenting with web development projects, learning new technologies, and showcasing personal portfolios. Restoring VistaPanel hosts on Free-for-Dev would ensure that developers continue to have access to this free hosting option.

Distinguishing VistaPanel from cPanel: To address any confusion surrounding VistaPanel, it would be helpful to provide a clear distinction between VistaPanel and cPanel hosts on the Free-for-Dev platform. This could include adding a separate category for VistaPanel hosts or clearly labeling them as "VistaPanel" to prevent any misinterpretation.

Proposed Solution:

Restore VistaPanel hosts: We request the Free-for-Dev platform administrators to consider bringing back VistaPanel hosts to the list of available hosting providers. This would allow developers to continue benefiting from the simplicity and accessibility that VistaPanel offers.

Clarify authenticity: To avoid any misunderstandings regarding the legitimacy of VistaPanel hosts, it would be beneficial to include a brief explanation or disclaimer emphasizing that VistaPanel is a distinct hosting control panel and not a fake version of cPanel.

Provide distinction: Consider implementing visual or categorization changes on the Free-for-Dev platform to clearly differentiate between cPanel hosts and VistaPanel hosts. This could involve labeling VistaPanel hosts prominently or providing a separate category or section for them.

By addressing these concerns and taking the proposed actions, Free-for-Dev can continue to provide an inclusive and diverse selection of hosting options for developers, while acknowledging the unique value that VistaPanel hosts bring to the community.