### PR TITLE
Updated Storj Free Plan limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [backblaze.com](https://www.backblaze.com/b2/) — Backblaze B2 cloud storage. Free 10 GB (Amazon S3-like) object storage for unlimited time
   * [filebase.com](https://filebase.com/) - S3 Compatible Object Storage Powered by Blockchain. 5 GB free storage for unlimited duration.
   * [scaleway](https://www.scaleway.com/en/object-storage/) — S3-Compatible Object Storage. Free 75 GB storage and external outgoing traffic(credit card required).
-  * [Storj](https://storj.io/) — Decentralised Private Cloud Storage for Apps and Developers. Free plan provides 1 Project, 150 GB storage, 150 GB bandwidth per month.
+  * [Storj](https://storj.io/) — Decentralised Private Cloud Storage for Apps and Developers. Free plan provides 1 Project, 25 GB storage, 25 GB bandwidth per month.
   * [Tebi](https://tebi.io/) - S3 compatibility object storage.Free 25 GB storage and 250GB outbound transfer.
   * [Idrive e2](https://www.idrive.com/e2/) - S3 compatibility object storage. 10 GB free storage and 10 GB download bandwidth per month.
   * [C2 Object Storage](https://c2.synology.com/en-us/pricing/object-storage) - S3 compatibility object storage. 15 GB free storage and 15 GB download per month.


### PR DESCRIPTION
Storj has changes their Free Plan offering, instead of 150 GB storage and bandwidth it's now 25 GB

See:
https://forum.storj.io/t/storj-free-tier-update-for-new-accounts-25-gb-storage/22155
https://docs.storj.io/dcs/billing-payment-and-accounts-1/pricing/free-tier
