### PR TITLE
remove fingerprintjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,6 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [Virgil Security](https://virgilsecurity.com/) — Tools and services for implementing end-to-end encryption, database protection, IoT security and more in your digital solution. Free for applications with up to 250 users.
   * [Virushee](https://virushee.com/) — Privacy-oriented file/data scanning powered by hybrid heuristic and AI-assisted engine. Possible to use internal dynamic sandbox analysis. Limited to 50MB per file upload
   * [Escape GraphQL Quickscan](https://escape.tech/) - One-click security scan of your GraphQL endpoints. Free, no login required.
-  * [FingerprintJS Browser Fingerprinting](https://www.fingerprint.com) - FingerprintJS is a browser fingerprinting library that queries browser attributes and computes a hashed visitor identifier from them. Unlike cookies and local storage, a fingerprint stays the same in incognito/private mode and even when browser data is purged. Free tier version of Pro has 20,000 Requests per month.
 
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
FingerpringJS free tier sunset on July 24, 2023. Removed from [Pricing page](https://fingerprint.com/pricing/).

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [ ] This is Software as a Service not self hosted
 * [ ] It has a free tier not just a free trial
 * [ ] The submission mentions what is free
 * [ ] The submission is not already present in the list
 * [ ] The service has contact details of those running it and a privacy policy
