### PR TITLE
Adding Aiven to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
    * [Code Search and Browsing](#code-search-and-browsing)
    * [Crash and Exception Handling](#crash-and-exception-handling)
    * [Data Visualization on Maps](#data-visualization-on-maps)
-   * [DBaaS](#dbaas)
+   * [Managed Data Services](#managed-data-services)
    * [Design and UI](#design-and-ui)
    * [Design Inspiration](#design-inspiration)
    * [Dev Blogging Sites](#dev-blogging-sites)
@@ -1155,8 +1155,9 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
 
 **[⬆️ Back to Top](#table-of-contents)**
 
-## DBaaS
+## Managed Data Services
 
+   * [Aiven](https://aiven.io/) - Aiven offers free PostgreSQL, MySQL and Redis plans on its open source data platform. Single node, 1 CPU, 1GB RAM and for PostgreSQL and MySQL, 5GB storage. Easy migration to larger plans or across clouds.
    * [airtable.com](https://airtable.com/) — Looks like a spreadsheet, but it's a relational database, unlimited bases, 1,200 rows/base and 1,000 API requests/month
    * [Astra](https://www.datastax.com/products/datastax-astra/) — Cloud Native Cassandra as a Service with [80GB free tier](https://www.datastax.com/products/datastax-astra/pricing)
    * [codehooks.io](https://codehooks.io/) — JavaScript serverless API/backend and database service with functions, Mongdb-ish queries, key/value lookups, a job system and a message queue. 1 instance free per project, 5000 records and 5000 calls/month free, 3 developers included. No credit-card required.


### PR DESCRIPTION
This PR proposes one addition and one modification:

- It adds [Aiven free plans](https://aiven.io/blog/free-plans-postgresql-mysql-redis) to the list
- It proposes a modification from using DBaaS to managed data services to cover a wider range of data services; not just databases

Thank you for compiling this awesome list.
<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [ x ] This is Software as a Service not self hosted
 * [ x ] It has a free tier not just a free trial
 * [ x ] The submission mentions what is free
 * [ x ] The submission is not already present in the list
 * [ x ] The service has contact details of those running it and a privacy policy
