### PR TITLE
Remove Algorithmia from APIs, Data and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [IP.City](https://ip.city) — 100 free IP geolocation requests per day
   * [A11yWatch](https://a11ywatch.com) - Powerful web accessibility tool at scale. Free site-wide web acessibility testing and beyond that resets daily.
   * [Abstract API](https://www.abstractapi.com) — API suite for a variety of use cases including IP geolocation, gender detection or even email validation.
-  * [algorithmia.com](https://algorithmia.com/) — Host algorithms for free. Includes free monthly allowance for running algorithms. Now with CLI support.
   * [Apify](https://www.apify.com/) — Web scraping and automation platform to create an API for any website and extract data. Ready-made scrapers, integrated proxies, and custom solutions. Free plan with $5 platform credits included every month.
   * [API Mocha](https://apimocha.com) - Completely free online API mocking for testing and prototyping.  Make up to 500 requests per day, fully customizable API responses, download mock rules as a Postman collection.
   * [APITemplate.io](https://apitemplate.io) - Auto-generate images and PDF documents with a simple API or automation tools like Zapier & Airtable. No CSS/HTML required. Free plan comes with 50 images/month and 3 templates.


### PR DESCRIPTION
Algorithmia got acquired by Datarobot:-

[Official Blog](https://www.datarobot.com/blog/datarobot-is-acquiring-algorithmia/)
[Bloomberg](https://www.bloomberg.com/press-releases/2021-07-27/datarobot-is-acquiring-algorithmia-enhancing-leading-mlops-architecture-for-the-enterprise)

No free tier now, only has a trial now, and that too for business e-mails only:- 

https://www.datarobot.com/trial/
https://www.datarobot.com/pricing/