### PR TITLE
add 3 services

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,6 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [Pullflow](https://pullflow.com) — Pullflow offers an AI-enhanced platform for code review collaboration across GitHub, Slack, and VS Code.
   * [Webex](https://www.webex.com/) — Video meetings with a free plan offering 40 minutes per meeting with 100 attendees.
   * [RingCentral](https://www.ringcentral.com/) — Video meetings with a free plan offering 50 minutes per meeting with 100 participants.
-  * [Whereby](https://whereby.com/) — Video meetings:1 room,100 attendees per meeting,Unlimited one-on-one meetings,Group meetings for up to 45 minutes;Video call API:2000 participant minutes monthly
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
metered.ca for their turn server,  https://www.metered.ca/pricing
webex for the meeting , https://pricing.webex.com/us/en/hybrid-work/meetings/
ringcentral for the meeting , https://www.ringcentral.com/office/plansandpricing.html 


notes:
i dont know why for most items the seperator is `—` and it is not the minus symbol but i am just copying that
after editing i found i am duplicating whereby so i reverted and thats why there is a commit saying "whereby already exists"