### PR TITLE
propose dappling network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ This list is the result of Pull Requests, reviews, ideas and work done by 1100+ 
   * [Alwaysdata](https://www.alwaysdata.com/) — 100 MB free web hosting with support for MySQL, PostgreSQL, CouchDB, MongoDB, PHP, Python, Ruby, Node.js, Elixir, Java, Deno, custom web servers, access via FTP, WebDAV and SSH; mailbox, mailing list and app installer included.
   * [Awardspace.com](https://www.awardspace.com) — Free web hosting + a free short domain, PHP, MySQL, App Installer, Email Sending & No Ads.
   * [Bubble](https://bubble.io/) — Visual programming to build web and mobile apps without code, free with Bubble branding.
+  * [dAppling Network](https://www.dappling.network/) - Decentralized web hosting platform for Web3 frontends focusing on increasing uptime, security, and providing an additional access point for users.
   * [DigitalOcean](https://www.digitalocean.com/pricing) - Build and deploy 3 static sites for free on the App Platform Starter tier.
   * [Drive To Web](https://drv.tw) — Host directly to the web from Google Drive & OneDrive. Static sites only. Free forever. One site per Google/Microsoft account.
   * [DuckDocs](https://duckdocs.com) - Markdown-powered documentation hosting, sort of like a hosted Docusaurus. Free for 10 pages per site.


### PR DESCRIPTION
Propose [dAppling Network](https://dappling.network) - a free web hosting service that makes it quick and easy to host static sites on IPFS

[docs](https://docs.dappling.network)

Thanks for reviewing :))

<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy
