### PR TITLE
Added Htmlrev.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1876,6 +1876,7 @@ Update Time, five active automations, webhooks.
 ## Other Free Resources
 
   * [Buff.tools](https://buff.tools/) - An all-in-one digital toolbox featuring Web, SEO, AI, Domain Management, unit conversion, calculators, and Image Manipulation Tools.
+  * [Htmlrev.com](https://htmlrev.com/) - Get 1000+ Selected free HTML, Bootstrap, Tailwind templates for websites, landing pages, coming soon, blogs, portfolios, ecommerce, dashboards and more.
   * [ElevateAI](https://www.elevateai.com) - Get up to 200 hours of audio transcription for free every month.
   * [get.localhost.direct](https://get.localhost.direct) — A better `*.localhost.direct` Wildcard public CA signed SSL cert for localhost development with sub-domain support
   * [Framacloud](https://degooglisons-internet.org/en/list/) — A list of Free/Libre Open Source Software and SaaS by the French non-profit [Framasoft](https://framasoft.org/en/).


### PR DESCRIPTION
Added **Htmlrev.com** to the list of "other free resources", **Htmlrev has a collection of free HTML templates for websites, landing pages, blogs, portfolios, ecommerce and dashboards**. Its totally free.

## Requirements

 * [ ✔] This is Software as a Service not self hosted
 * [ ✔] It has a free tier not just a free trial
 * [ ✔] Pricing information is clearly visible without signup or phone calls
 * [ ✔] The submission mentions what is free
 * [ ✔] The submission is not already present in the list
 * [ ✔] The service has contact details of those running it and a privacy policy
