### PR TITLE
Removed MeiliSearch from Searches. No longer free

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,7 +876,6 @@ This list results from Pull Requests, reviews, ideas, and work done by 1100+ peo
   * [Magny](https://magny.io) - SaaS service that helps implement command palettes (e.g. in-app search), which significantly decreases the time users find anything in an app, leveraging the user experience and efficiency.
   * [searchly.com](http://www.searchly.com/) — Free 2 indices and 20 MB storage
   * [pagedart.com](https://pagedart.com/) - AI search as a service the free tier includes 1,000 Documents and 50,000 searches. Larger free decks are possible for worthwhile projects.
-  * [Meilisearch](https://www.meilisearch.com/) - An open-source, lightning-fast, and hyper-relevant search engine that fits effortlessly into your apps, websites, and workflow. The free plan includes 100K documents and 10K searches/month.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Removed **MeiliSearch** entry from the [Search](https://free-for.dev/#/?id=search) section since it's no longer free
