### PR TITLE
remove harperdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,6 @@ Update Time, five active automations, webhooks.
    * [codehooks.io](https://codehooks.io/) — JavaScript serverless API/backend and database service with functions, Mongdb-ish queries, key/value lookups, a job system, and a message queue. One instance free per project, 5000 records, 5000 calls/month free, three developers included. No credit-card required.
    * [CrateDB](https://crate.io/) - Distributed Open Source SQL database for real-time analytics. [Free Tier CRFREE](https://crate.io/lp-crfree): One-node with 2 CPUs, 2 GiB of memory, 8 GiB of storage. One cluster per organization, no payment method needed.
    * [FaunaDB](https://fauna.com/) — Serverless cloud database with native GraphQL, multi-model access, and daily free tiers up to 100 MB
-   * [HarperDb](https://harperdb.io/) — Serverless cloud database, with dynamic schema based on JSON, 3000 IOPS with 1GB storage
    * [Upstash](https://upstash.com/) — Serverless Redis with free tier up to 10,000 requests per day, 256MB max database size, and 20 concurrent connections
    * [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) — free tier gives 512 MB
    * [redsmin.com](https://www.redsmin.com/) — Online real-time monitoring and administration service for Redis, Monitoring for 1 Redis instance free


### PR DESCRIPTION
https://www.harperdb.io/pricing

In a email they sent to free users
```
Important Alert for Free HarperDB Cloud Users
-------
Hi <name>​,

We hope you’ve been enjoying your free cloud instance of HarperDB. This message is to inform you that we are making changes to our freemium/premium model due to recent AWS price increases.

On January 19th, 2024, free HarperDB Cloud instances will be eliminated. To keep your instance, you will need to upgrade to a paid instance by 1/19/24. In an effort to help smooth this transition, we are granting a $33 credit to cover your first month.

Enter coupon code CLOUDUPGRADE in the coupons section of the billing page of the HarperDB Studio to apply the credit to your account.

HarperDB Cloud instances start at $32.30/month. You can upgrade your instance with these instructions, be sure to upgrade to a 1GB or above instance by January 19th, 2024 to preserve your data.

Why the change?

AWS announced a new charge that will come into effect starting in February of 2024, which will cause our AWS cloud hosting costs to increase dramatically. We did not make this decision lightly, but the change is necessary so that we are able to continuously support our users and build an awesome product.

Keep in mind that you can deploy HarperDB wherever you’d like for free, on your own infrastructure or via Docker, npm, or DigitalOcean deployment.

Please respond to this email to let us know if you have any questions, and we appreciate your understanding.

Best,


```