### PR TITLE
Remove PageCDN from the list (CDN and Protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,6 @@ This list results from Pull Requests, reviews, ideas, and work done by 1100+ peo
   * [jsdelivr.com](https://www.jsdelivr.com/) — A free, fast, and reliable open-source CDN. Supports npm, GitHub, WordPress, Deno, and more.
   * [Microsoft Ajax](https://docs.microsoft.com/en-us/aspnet/ajax/cdn/overview) — The Microsoft Ajax CDN hosts popular third-party JavaScript libraries such as jQuery and enables you to easily add them to your Web application
   * [ovh.ie](https://www.ovh.ie/ssl-gateway/) — Free DDoS protection and SSL certificate
-  * [PageCDN.com](https://pagecdn.com/) - Offers free Public CDN for everyone and free Private CDN for open source/nonprofits.
   * [Skypack](https://www.skypack.dev/) — The 100% Native ES Module JavaScript CDN. Free for 1 million requests per domain per month.
   * [raw.githack.com](https://raw.githack.com/) — A modern replacement of **rawgit.com** which simply hosts file using Cloudflare
   * [section.io](https://www.section.io/) — A simple way to spin up and manage a complete Varnish Cache solution. Supposedly free forever for one site


### PR DESCRIPTION
**[Pagecdn.com ](https://pagecdn.com/)is returning a Cloudways 403 error Page**

![Screenshot from 2023-12-23 13-57-48](https://github.com/ripienaar/free-for-dev/assets/97863234/27710433-663f-4056-9d86-2e136f095ead)
