### PR TITLE
Add Data Dead Drop to APIs & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1100+ peo
   * [CurlHub](https://curlhub.io) — Proxy service for inspecting and debugging API calls. The free plan includes 10,000 requests per month.
   * [CurrencyScoop](https://currencyscoop.com) - Realtime currency data API for fintech apps. The free plan includes 5,000 calls per month.
   * [Cube](https://cube.dev/) - Cube helps data engineers and application developers access data from modern data stores, organize it into consistent definitions, and deliver it to every application. The fastest way to use Cube is with Cube Cloud, which has a free tier with 1GB of data passing through each month.
+  * [Data Dead Drop](https://datadeaddrop.com) - Simple, free file sharing. Data self-destroys after access. Upload and download data via the browser or your favorite command line client.  
   * [Data Fetcher](https://datafetcher.com) - Connect Airtable to any application or API with no code. Postman-like interface for running API requests in Airtable. Pre-built integrations with dozens of apps. The free plan includes 100 runs per month.
   * [Dataimporter.io](https://www.dataimporter.io) - Tool for connecting, cleaning, and importing data into Salesforce. Free Plan includes up to 20,000 records per month.
   * [Datalore](https://datalore.jetbrains.com) - Python notebooks by Jetbrains. Includes 10 GB of storage and 120 hours of runtime each month.


### PR DESCRIPTION
Data Dead Drop provides anonymous file sharing for small files. Useful for CIs or just getting data from one machine to another if you have nothing but cURL and an internet connection. 

## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial. 
 * [X] Pricing information is clearly visible without signup or phone calls
 * [X] The submission mentions what is free
 * [X] The submission is not already present in the list
 * [X] The service has contact details of those running it and a privacy policy
