### PR TITLE
Remove Buff.tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1897,7 +1897,6 @@ Update Time, five active automations, webhooks.
 
 ## Other Free Resources
 
-  * [Buff.tools](https://buff.tools/) - An all-in-one digital toolbox featuring Web, SEO, AI, Domain Management, unit conversion, calculators, and Image Manipulation Tools.
   * [ElevateAI](https://www.elevateai.com) - Get up to 200 hours of audio transcription for free every month.
   * [get.localhost.direct](https://get.localhost.direct) — A better `*.localhost.direct` Wildcard public CA signed SSL cert for localhost development with sub-domain support
   * [Framacloud](https://degooglisons-internet.org/en/) — A list of Free/Libre Open Source Software and SaaS by the French non-profit [Framasoft](https://framasoft.org/en/).


### PR DESCRIPTION
This Pull Request was create due to this website looks does not exist anymore.

for `buff.tools`, there is result at global.
![image](https://github.com/ripienaar/free-for-dev/assets/10257291/1e752298-e322-4c5f-b333-bedd5f3f68f6)

for `www.buff.tools`, i got this:
![image](https://github.com/ripienaar/free-for-dev/assets/10257291/dd341ab9-6c7d-4d68-8036-46ef087dc4f7)

maybe we should remove this website if it still unavaliable after a month?