### PR TITLE
Add pre-commit.ci service to CI/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1100+ peo
   * [deployhq.com](https://www.deployhq.com/) — 1 project with ten daily deployments (30 build minutes/month)
   * [drone](https://cloud.drone.io/) - Drone Cloud enables developers to run Continuous Delivery pipelines across multiple architectures - including x86 and Arm (both 32-bit and 64-bit) - all in one place
   * [LayerCI](https://layerci.com) — CI for full stack projects. One full stack preview environment with 5GB memory & 3 CPUs.
+  * [pre-commit.ci](https://pre-commit.ci) - CI service for the [pre-commit](https://pre-commit.com) framework will always be free for open source repositories.
   * [semaphoreci.com](https://semaphoreci.com/) — Free for Open Source, 100 private builds per month
   * [Squash Labs](https://www.squash.io/) — creates a VM for each branch and makes your app available from a unique URL, Unlimited public & private repos, Up to 2 GB VM Sizes.
   * [styleci.io](https://styleci.io/) — Public GitHub repositories only


### PR DESCRIPTION
<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [ X ] This is Software as a Service not self hosted
 * [ X ] It has a free tier not just a free trial
 * [ X ] Pricing information is clearly visible without signup or phone calls
   * https://github.com/marketplace/pre-commit-ci
 * [ X ] The submission mentions what is free
 * [ X ] The submission is not already present in the list
 * [ X ] The service has contact details of those running it and a privacy policy
   * pre-commit ci, LLC (postal and email addresses)
   * https://pre-commit.ci/privacy_policy.html
