### PR TITLE
Remove Platform9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1752,7 +1752,6 @@ Update Time, five active automations, webhooks.
   * [Docker Hub](https://hub.docker.com) — One free private repository and unlimited public repositories to build and store Docker images
   * [Play with Docker](https://labs.play-with-docker.com/) — A simple, interactive, fun playground to learn Docker.
   * [quay.io](https://quay.io/) — Build and store container images with unlimited free public repositories
-  * [Platform9](https://platform9.com/) - Managed Kubernetes plane. The free plan offers management capabilities for up to 3 clusters & 20 nodes. Just so you know, you must provide cluster infrastructure by yourself.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Formerly discussed in https://github.com/ripienaar/free-for-dev/pull/1464

The two links mentioned in that issue are dead. And I can't find signup link. They only have "free consultation" now.