### PR TITLE
Remove Light CDN from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,6 @@ This list results from Pull Requests, reviews, ideas, and work done by 1100+ peo
   * [weserv](https://images.weserv.nl/) — An image cache & resize service. Manipulate images on the fly with a worldwide cache.
   * [Namecheap Supersonic](https://www.namecheap.com/supersonic-cdn/#free-plan) — Free DDoS protection
   * [Gcore](https://gcorelabs.com/) Global content delivery network, 1 TB and 1 million requests per month free and free DNS hosting
-  * [LightCDN](https://www.lightcdn.com) - Free 100GB CDN with eight international Pop. Unlimited HTTP(S) requests.
   * [CacheFly](https://portal.cachefly.com/signup/free2023) - Up to 5 TB per month of Free CDN traffic, 19 Core PoPs , 1 Domain and Universal SSL.
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
The reason for this removal is that Light CDN has discontinued their 100 GB per month free tier plan. Instead, they now provide a 500 GB one-time package for 30 days.

**Sources:**
1. Notifications Page  
Link: https://www.lightcdn.com/en-US/notify/4e200ea42d2049a5b082a42ee41e7a75

![image](https://github.com/ripienaar/free-for-dev/assets/97863234/c365bf71-6f04-4bc2-9ad8-9ea5f6fbae46)

2. New Pricing Page
Link: https://www.lightcdn.com/en-US/pricing

![image](https://github.com/ripienaar/free-for-dev/assets/97863234/86e9892a-6282-4ff8-a31a-41af30ed65b9)
