### PR TITLE
Add Statsig to Feature Toggles list

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1100+ peo
   * [GrowthBook](https://growthbook.io) - Open source feature flag and A/B testing provider with built-in Bayesian statistical analysis engine. Free for up to 3 users, unlimited feature flags and experiments.
   * [Molasses](https://www.molasses.app) - Powerful feature flags and A/B testing. Free up to 3 environments with five feature flags each.
   * [Toggled.dev](https://www.toggled.dev) - Enterprise-ready, scalable multi-regional feature toggles management platform. Free plan up to 10 flags, two environments, unlimited requests. SDK, analytics dashboard, release calendar, Slack notifications, and all other features are included in the endless free plan.
+  * [Statsig](https://www.statsig.com?ref=gh_ffd) - A powerful platform for feature management, A/B testing, Analytics, and more.  The generous free plan includes unlimited seats, flags, experiments, and dynamic configurations up to 1M events/month.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
## Requirements
 * [X] This is Software as a Service not self hosted
 * [X] It has a free tier not just a free trial
 * [X] Pricing information is clearly visible without signup or phone calls
 * [X] The submission mentions what is free
 * [X] The submission is not already present in the list
 * [X] The service has contact details of those running it and a privacy policy
