### PR TITLE
remove scramjet

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,7 +761,6 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [eyeson API](https://developers.eyeson.team/) - A video communication API service based on WebRTC (SFU, MCU) to build video platforms. Allows real-time data Injection, Video Layouts, Recordings, a fully featured hosted web UI (quickstart) or packages for custom UIs. Has a [free tier for developers](https://apiservice.eyeson.com/api-pricing) with 1000 meeting minutes a month.
   * [Upstash Kafka](https://upstash.com/kafka) - Serverless Kafka Cloud offering with per-request-pricing. It has a free tier with a maximum of 10,000 messages per day.
   * [webpushr](https://www.webpushr.com/) - Web Push Notifications - Free for upto 10k subscribers, unlimited push notifications, in-browser messaging
-  * [Scramjet Cloud Platform Beta](https://www.scramjet.org/#join-beta) - An end-to-end stream processing platform in free beta and offering 15 petabyte-seconds of free compute after the beta ends.
   * [httpSMS](https://httpsms.com) - Send and receive text messages using your Android phone as an SMS Gateway. Free to send and receive up to 200 messages per month.
   * [EMQX Serverless](https://www.emqx.com/en/cloud/serverless-mqtt) - Scalable and secure serverless MQTT broker you can get in seconds. 1M session minutes/month free forever (no credit card required).
 


### PR DESCRIPTION
https://scramjet.org/pricing/

```
Trial period
30 days of Scramjet Cloud and Self-Hosted Hub add-on product for free

Full version of Scramjet Cloud

Up to one Self Hosted Hub

1 GB RAM Managed Hub

10 GB Egress transfer

25k instance execusions

(5 at the same time)

5 GB Sequence storage

[Try for free](https://console.scramjet.cloud/?screen=register)
No credit card required
```
free 1-month trial is not eligible for this list,I remember trials need to be at least 1 year long