### PR TITLE
Added Hydrozen.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [freeboard.io](https://freeboard.io/) — Free for public projects. Dashboards for your Internet of Things (IoT) projects
   * [Grafana Cloud](https://grafana.com/products/cloud/) - Grafana Cloud is a composable observability platform that integrates metrics and logs with Grafana. Free: 3 users, ten dashboards, 100 alerts, metrics storage in Prometheus and Graphite (10,000 series, 14 days retention), logs storage in Loki (50 GB of logs, 14 days retention)
   * [healthchecks.io](https://healthchecks.io) — Monitor your cron jobs and background tasks. Free for up to 20 checks.
+  * [Hydrozen.io](https://hydrozen.io) — Uptime monitoring & Status pages, Free plan: 10 Uptime monitor, 5 heartbeat monitors, 1 Domain monitor and 1 Statuspage free.
   * [inspector.dev](https://www.inspector.dev) - A complete Real-Time monitoring dashboard in less than one minute with a free forever tier.
   * [instrumentalapp.com](https://instrumentalapp.com) - Beautiful and easy-to-use application and server monitoring with up to 500 metrics and 3 hours of data visibility for free
   * [keychest.net/speedtest](https://keychest.net/speedtest) - Independent speed test and TLS handshake latency test against Digital Ocean


### PR DESCRIPTION
Added Hydrozen.io to the list of monitoring tools. Hydrozen.io has a free forever plan which supports 10 uptime monitors, 5 heartbeat monitors, 1 Domain & SSL monitor, 1 DNS monitor and 1 Statuspage.

<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy
