### PR TITLE
Add additional free subdomain registry services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,8 +1278,17 @@ Update Time, five active automations, webhooks.
 ## Domain
 
   * [eu.org](https://nic.eu.org) — Free eu.org domain. The request is usually approved in 14 days.
+  * [getlocalcert.net](https://www.getlocalcert.net) — Free subdomains for private network use.
+  * [is-a.dev](https://www.is-a.dev) — Free is-a.dev subdomain for developers.
+  * [is-a-good.dev](https://is-a-good.dev) — A free is-a-good-dev subdomain for developers.
+  * [js.org](https://js.org) — Free js.org subdomains for GitHub Pages for the JavaScript community.
+  * [ngo.us](https://nic.ngo.us) — Free `.ngo.us` subdomains for verified not-for-profit organizations, NGOs, and similar initiatives.
+  * [nyc.mn](https://dot.nyc.mn) — Free subdomains for individuals and businesses related to New York City. New York City IP address required for application.
+  * [obl.ong](https://obl.ong) — Free, quality subdomains for all, backed by a nonprofit.
+  * [Open Domains](https://open-domains.net) — Free subdomains for personal sites, open-source projects, and more.
+  * [OpenHost](https://registry.openhost.uk) — A free subdomain service offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it` with Mozilla PSL support, and on `pride.moe`, `pride.ngo` without Mozilla PSL support.
   * [pp.ua](https://nic.ua/) — Free pp.ua subdomains.
-  * [us.kg](https://nic.us.kg/) - Free us.kg subdomains.
+  * [us.kg](https://nic.us.kg/) — Free us.kg subdomains.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
   * Fake / Temporary / Ephemeral email generators, we have enough of those
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

**Met:**

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list

**Partially met (most of them have privacy policies, explanation below)**

 * [x] The service has contact details of those running it and a privacy policy 

## Explanation

All of these services are recognized/included by Mozilla's PSL.

Sourced from https://github.com/wdhdev/free-for-life:

| Website | Description | [PSL](https://github.com/publicsuffix/list) Status |
|:-:|-|:-:|
| [getlocalcert.net](https://www.getlocalcert.net) | Free subdomains for private network use. | ✅ |
| [is-a.dev](https://www.is-a.dev) | Free is-a.dev subdomain for developers. | ✅ |
| [is-a-good.dev](https://is-a-good.dev) | A free is-a-good-dev subdomain for developers. | ✅ |
| [js.org](https://js.org) | Free js.org subdomains for GitHub Pages for the JavaScript community. | ✅ |
| [NGO.us](https://nic.ngo.us) | Free `.ngo.us` subdomains for verified not-for-profit organizations, NGOs, and similar initiatives. | ✅ |
| [NYC.mn](https://dot.nyc.mn) | Free subdomains for individuals and businesses related to New York City. New York City IP address required for application. | ✅ |
| [Obl.ong](https://obl.ong) | Free, quality subdomains for all, backed by our nonprofit. Get yourname.obl.ong and become a voting member in our organization today! | ✅ |
| [Open Domains](https://open-domains.net) | Free subdomains for personal sites, open-source projects, and more. | ✅ |
| [Open Host](https://registry.openhost.uk) | A free subdomain service offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it` with PSL support, and on `pride.moe`, `pride.ngo` without PSL support. | ℹ️ `pride.moe` and `pride.ngo` are not listed, the rest are however. |
| [pp.ua](https://pp.ua) | Free pp.ua subdomains. | ✅ |
| [us.kg](https://nic.us.kg) | Free subdomain service run by the nonprofit DigitalPlat Foundation, supported by the Hack Foundation. | ✅ |

Please note that these services do not appear to have a privacy policy, but I might have overlooked something. Feel free to remove them from my PR if they do not meet the requirements.

- https://www.is-a.dev  
- https://obl.ong  
- https://open-domains.net
