### PR TITLE
Remove Metered.ca free offering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,7 +1348,6 @@ Update Time, five active automations, webhooks.
   * [LocalXpose](https://localxpose.io) — Reverse proxy that enables you to expose your localhost servers to the internet. The free plan has 15 minutes tunnel lifetime.
   * [Traefik-Hub](https://traefik.io/traefik-hub/) - Publish locally, running services over a tunnel to a public custom URL and secure them with access control. Free for 5 services in one cluster.
   * [Expose](https://expose.dev/) - Expose local sites via secure tunnels. The free plan includes an EU Server, Random subdomains, and Single users.
-  * [Metered](https://www.metered.ca/) — Free TURN server with 50GB included monthly TURN usage.
   * [btunnel](https://www.btunnel.in/) — Expose localhost and local tcp server to the internet. Free plan includes file server, custom http request and response headers, basic auth protection and 1 hour tunnel timeout.
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
Metered.ca reduced their free tier from 50GB TURN traffic per month to 500MB. See https://www.metered.ca/pricing

<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
   * Fake / Temporary / Ephemeral email generators, we have enough of those
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [ ] This is Software as a Service not self hosted
 * [ ] It has a free tier not just a free trial
 * [ ] Pricing information is clearly visible without signup or phone calls
 * [ ] The submission mentions what is free
 * [ ] The submission is not already present in the list
 * [ ] The service has contact details of those running it and a privacy policy

