### PR TITLE
add `is-a.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,7 @@ Update Time, five active automations, webhooks.
 ## Domain
 
   * [eu.org](https://nic.eu.org) — Free eu.org domain. The request is usually approved in 14 days.
+  * [is-a.dev](https://is-a.dev) - Grab your own sweet-looking '.is-a.dev' subdomain.
   * [pp.ua](https://nic.ua/) — Free pp.ua subdomains.
   * [us.kg](https://nic.us.kg/) - Free us.kg subdomains.
 


### PR DESCRIPTION
<!--
 ### Free SaaS Offering Submission

 Thank you for contributing to this list. This list is for **SaaS**
 services that offer a **free tier** to help developers evaluate and
 build something that users can later use and get support for.

 The focus of this list is quite broad but we try to keep things
 limited to that which infrastructure developers, like DevOps Practitioners,
 would find useful.

 This list is the result of more than a thousand people contributing
 to make something useful, we appreciate your efforts.

 ### Code of Conduct

 We are not here to argue with you. If you are argumentative, abusive,
 lie or missrepresent your service or are otherwise anti-social we will
 block you.

 ### Services we do not accept

   * cPanel like PHP + MySQL hosting services.
   * Free dns services that are generic frontends to CloudFlare or similar
   * Services that are verbatim copy pastes of others while adding no value
   * Fake / Temporary / Ephemeral email generators, we have enough of those
-->

## Requirements

<!-- This is only for new submissions -->
<!-- Please ensure your submission ticks all of the requirements -->

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy

---

I'm aware you no longer allow free subdomain services, however I was hoping you would make an exception for is-a.dev as we are a well established subdomain service which has been around since 2020. We would also not fall under the verbatim copy paste rule either as we have our own custom made CI, with custom tests, all of which were made by myself.

We have over 3,000 users with over 5,500 subdomains. We are listed on Mozilla's [Public Suffix List](https://github.com/publicsuffix/list). We also have an open source software sponsorship from [Cloudflare](https://cloudflare.com) which provides us with their enterprise services.

Also, I think this is a good fit for the list as it is a short domain for developers, and is extremely popular. It is also worth noting that eu.org has not been active for around a year now, which has lead a few of their users to us.

I hope you can make an exception for us, if you cannot, I do understand. However I think listing us will benefit the majority of users visiting Free For Dev.

https://is-a.dev
https://github.com/is-a-dev/register