### PR TITLE
Add Railway to the list of free tools and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,6 +1174,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Zeabur](https://zeabur.com) - Deploy your services with one click. Free for three services, with US$ 5 free credits per month.
   * [mogenius](https://mogenius.com) - Easily build, deploy, and run services on Kubernetes. The free tier supports connecting a local Kubernetes with mogenius, enabling individual developers to create a production-like test environment on their machine.
   * [genezio](https://genezio.com/) - A serverless function provider offers 1 million function calls, 100GB of bandwidth, and 10 cron jobs per month for free, exclusively for non-commercial or academic use.
+  * [Railway](https://railway.app/) - A modern platform for deploying apps and databases with a free tier.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
This PR adds Railway to the list of free tools and services. It’s a modern platform for deploying apps and databases with a free tier. It was added to PaaS list.