### PR TITLE
Add manubes no-code platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,8 +1256,6 @@ Update Time, five active automations, webhooks.
   * [Superblocks](https://superblocks.com/) — Open enterprise application platform designed for developers and semi-technical teams. Use AI to generate, edit visually and extend with code. Govern centrally with integrations, authentication, permissions & audit logs. 
   * [ToolJet](https://www.tooljet.com/) — Extensible low-code framework for building business applications. Connect to databases, cloud storages, GraphQL, API endpoints, Airtable, etc., and build apps using drag-and-drop application builder.
   * [UI Bakery](https://uibakery.io) — Low-code platform that enables faster building of custom web applications. Supports building UI using drag and drop with a high level of customization through JavaScript, Python, and SQL. Available as both cloud and self-hosted solutions. Free for up to 5 users.
-  * [Mendix](https://www.mendix.com/) — Rapid Application Development for Enterprises, unlimited accessible sandbox environments supporting total users, 0.5 GB storage and 1 GB RAM per app. Also, Studio and Studio Pro IDEs are allowed in the free tier.
-  * [lil'bots](https://www.lilbots.io/) - write and run scripts online utlizing free built-in APIs like OpenAI, Anthropic, Firecrawl and others. Great for building AI agents / internal tooling and sharing with team. Free-tier includes full access to APIs, AI coding assistant and 10,000 execution credits / month.
   * [manubes](https://www.manubes.com) - Powerful no-code cloud platform with a focus on industrial production management. All features are included in the free tier ([also available in german](https://www.manubes.de)).
 
 **[⬆️ Back to Top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -1254,6 +1254,7 @@ Update Time, five active automations, webhooks.
   * [UI Bakery](https://uibakery.io) — Low-code platform that enables faster building of custom web applications. Supports building UI using drag and drop with a high level of customization through JavaScript, Python, and SQL. Available as both cloud and self-hosted solutions. Free for up to 5 users.
   * [Mendix](https://www.mendix.com/) — Rapid Application Development for Enterprises, unlimited accessible sandbox environments supporting total users, 0.5 GB storage and 1 GB RAM per app. Also, Studio and Studio Pro IDEs are allowed in the free tier.
   * [lil'bots](https://www.lilbots.io/) - write and run scripts online utlizing free built-in APIs like OpenAI, Anthropic, Firecrawl and others. Great for building AI agents / internal tooling and sharing with team. Free-tier includes full access to APIs, AI coding assistant and 10,000 execution credits / month.
+  * [manubes](https://www.manubes.de) - Powerful no-code cloud platform with a focus on industrial production management. All features are included in the free tier.
 
 **[⬆️ Back to Top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1254,7 +1254,7 @@ Update Time, five active automations, webhooks.
   * [UI Bakery](https://uibakery.io) — Low-code platform that enables faster building of custom web applications. Supports building UI using drag and drop with a high level of customization through JavaScript, Python, and SQL. Available as both cloud and self-hosted solutions. Free for up to 5 users.
   * [Mendix](https://www.mendix.com/) — Rapid Application Development for Enterprises, unlimited accessible sandbox environments supporting total users, 0.5 GB storage and 1 GB RAM per app. Also, Studio and Studio Pro IDEs are allowed in the free tier.
   * [lil'bots](https://www.lilbots.io/) - write and run scripts online utlizing free built-in APIs like OpenAI, Anthropic, Firecrawl and others. Great for building AI agents / internal tooling and sharing with team. Free-tier includes full access to APIs, AI coding assistant and 10,000 execution credits / month.
-  * [manubes](https://www.manubes.de) - Powerful no-code cloud platform with a focus on industrial production management. All features are included in the free tier.
+  * [manubes](https://www.manubes.com) - Powerful no-code cloud platform with a focus on industrial production management. All features are included in the free tier ([also available in german](https://www.manubes.de)).
 
 **[⬆️ Back to Top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1256,7 +1256,7 @@ Update Time, five active automations, webhooks.
   * [Superblocks](https://superblocks.com/) — Open enterprise application platform designed for developers and semi-technical teams. Use AI to generate, edit visually and extend with code. Govern centrally with integrations, authentication, permissions & audit logs. 
   * [ToolJet](https://www.tooljet.com/) — Extensible low-code framework for building business applications. Connect to databases, cloud storages, GraphQL, API endpoints, Airtable, etc., and build apps using drag-and-drop application builder.
   * [UI Bakery](https://uibakery.io) — Low-code platform that enables faster building of custom web applications. Supports building UI using drag and drop with a high level of customization through JavaScript, Python, and SQL. Available as both cloud and self-hosted solutions. Free for up to 5 users.
-  * [manubes](https://www.manubes.com) - Powerful no-code cloud platform with a focus on industrial production management. All features are included in the free tier ([also available in german](https://www.manubes.de)).
+  * [manubes](https://www.manubes.com) - Powerful no-code cloud platform with a focus on industrial production management. Free for one user with 1 million workflow activities a month ([also available in german](https://www.manubes.de)).
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Platform can be used for free without feature limitations. Storage is limited to 0.5 GB and workflow executions are limited to 1,000,000 activities per month.
EN: [manubes.com](https://www.manubes.com)
DE: [manubes.de](https://www.manubes.de)

* [X] This is Software as a Service not self hosted
* [X] It has a free tier not just a free trial
* [ ] Pricing information is clearly visible without signup or phone calls
* [X] The submission mentions what is free
* [X] The submission is not already present in the list
* [X] The service has contact details of those running it and a privacy policy

Unfortunately the pricing for the paid tiers are not shown on the website.

