### PR TITLE
Add Zenable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 
 ## Generative AI
 
+  * [Zenable](https://zenable.io) - Instantly auto-fix outputs from tools like Cursor, Windsurf, and Copilot to meet your company's quality and compliance standards using guardrails built with Policy as Code. The free tier includes unlimited MCP server usage and 25 free automated pull request reviews per day via the GitHub App.
   * [Keywords AI](https://keywordsai.co) - The best LLM monitoring platform. One format to call 200+ LLMs with 2 lines of code. 10,000 free requests every month and $0 for platform features!
   * [Portkey](https://portkey.ai/) - Control panel for Gen AI apps featuring an observability suite & an AI gateway. Send & log up to 10,000 requests for free every month.
   * [Braintrust](https://www.braintrustdata.com/) - Evals, prompt playground, and data management for Gen AI. Free plan gives upto 1,000 private eval rows/week.


### PR DESCRIPTION
This could fit in a couple of different buckets but I thought Generative AI was best, since the main feature is the MCP server which hooks it into the agentic loops of IDEs like Cursor, Windsurf, VS Code Copilot, etc. I also considered Code Quality.

Previous PR: https://github.com/ripienaar/free-for-dev/pull/3737
- There was [a question](https://github.com/ripienaar/free-for-dev/pull/3737#discussion_r2118100852) about if the MCP server is a SaaS; [it is](https://github.com/ripienaar/free-for-dev/pull/3737#discussion_r2133044347)

## Requirements

 * [X] This is Software as a Service not self hosted
 * [X] It has a free tier not just a free trial
 * [X] Pricing information is clearly visible without signup or phone calls
 * [X] The submission mentions what is free
 * [X] The submission is not already present in the list
 * [X] The service has contact details of those running it and a privacy policy
   * The privacy policy is [here](https://www.zenable.io/privacy-policy)