### PR TITLE
fix: Add Light- Dark theme to Octocat logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,20 @@
 
       gtag('config', 'G-DLYKZXPL9J');
     </script>
+    <style>
+      .github-corner svg {
+        fill: #ebebeb;        
+        color: #151513;      
+      }
+      html.dark .github-corner svg {
+        fill: #151513;      
+        color: #fff;         
+      }
+      .github-corner svg {
+        transition: fill 0.3s ease, color 0.3s ease;
+      }
+    </style>
+
   </head>
 
   <body>


### PR DESCRIPTION
## fix: Add Light- Dark theme to Octocat logo
## I made this contribution regarding the irresponsive octo cat logo on the to right corner which is in green color always irrespective to theme selected by user

![Screenshot 2025-06-25 213826](https://github.com/user-attachments/assets/341fd3f2-bfac-4920-a3f2-4c424295c11d)

![Screenshot 2025-06-25 213923](https://github.com/user-attachments/assets/66400ce7-d1a8-4f23-b860-22c868b0d1a9)

## I made minor CSS changes for logo so that its color changes with theme

![Screenshot 2025-06-25 214025](https://github.com/user-attachments/assets/27e23236-affd-4ecb-9a06-e9080feb2079)

![Screenshot 2025-06-25 214051](https://github.com/user-attachments/assets/0f1df353-7cd6-4d7d-9534-2dfb493061f4)



