### PR TITLE
Add DevNet Academy to Education section

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Full Stack Open](https://fullstackopen.com/en/) – Free university-level course on modern web development with React, Node.js, GraphQL, TypeScript, and more. Fully online and self-paced.
   * [edX](https://www.edx.org/) - Offers access to over 4,000 free online courses from 250 leading institutions, including Harvard and MIT, specializing in computer science, engineering, and data science.
   * [Django-tutorial.dev](https://django-tutorial.dev) - Free online guides for learning Django as their first framework & gives free dofollow backlink to articles written by users.
+  * [DevNet Academy](https://devnet-academy.com/) – Free, self-paced training for the Cisco DevNet Expert / CCIE Automation certification. Covers Python Click and Flask-RESTx.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Website
* https://devnet-academy.com/

## Description
DevNet Academy offers a free, self-paced sample course to help network engineers start preparing for the Cisco DevNet Expert / CCIE Automation certification. It includes lessons on Python Click and Flask-RESTx, and fun API coding challenge.

Free tier:
* Lesson about Python Click
* Lesson about Flask-RESTx
* Star Wars-themed API challenge
* Access to workbook

Pricing:
* The sample course is free
* Full access to the complete training program and mentoring is available as a paid upgrade

Contact:
* info@devnet-academy.com

Privacy Policy
* https://devnet-academy.com/privacy-policy/