### PR TITLE
Add TextAI API to Generative AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,6 +979,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Pollinations.AI](https://pollinations.ai/) - easy-to-use, free image generation AI with free API available. No signups or API keys required, and several option for integrating into a website or workflow. [#opensource](https://github.com/pollinations/pollinations)
   * [Portkey](https://portkey.ai/) - Control panel for Gen AI apps featuring an observability suite & an AI gateway. Send & log up to 10,000 requests for free every month.
   * [ReportGPT](https://ReportGPT.app) - AI Powered Writing Assistant. The entire platform is free as long as you bring your own API key.
+  * [TextAI API](https://textai-api.overtek.deno.net) - AI text processing API (summarize, extract keywords, translate) with 100 free credits on signup. Pay-per-use with USDC on Solana, no credit card or subscription required. [#opensource](https://github.com/mokchou/textai-api)
   * [Zenable](https://zenable.io) - Instantly auto-fix outputs from tools like Cursor, Windsurf, and Copilot to meet your company's quality and compliance standards using guardrails built with Policy as Code. The free tier includes 100 tools calls per day to the MCP server and 25 free automated pull request reviews per day via the GitHub App.
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
## What

Adds [TextAI API](https://textai-api.overtek.deno.net) to the Generative AI section.

## Description

TextAI API is an AI text processing API (summarize, extract keywords, translate) that offers:

- **100 free credits** on signup, no credit card required
- Pay-per-use with USDC on Solana (optional, for additional credits)
- Open source: https://github.com/mokchou/textai-api

The entry follows the existing format and is placed alphabetically in the Generative AI section.