### PR TITLE
Add GrugBot420 - Free AI CLI Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Portkey](https://portkey.ai/) - Control panel for Gen AI apps featuring an observability suite & an AI gateway. Send & log up to 10,000 requests for free every month.
   * [ReportGPT](https://ReportGPT.app) - AI Powered Writing Assistant. The entire platform is free as long as you bring your own API key.
   * [Zenable](https://zenable.io) - Instantly auto-fix outputs from tools like Cursor, Windsurf, and Copilot to meet your company's quality and compliance standards using guardrails built with Policy as Code. The free tier includes 100 tools calls per day to the MCP server and 25 free automated pull request reviews per day via the GitHub App.
+  * [GrugBot420](https://github.com/grug-group420/grugbot420) - Open-source AI-powered CLI assistant with neuromorphic intelligence. Completely free and self-hosted, zero dependencies, built with Bun.js. Try it at grug-group420.github.io/portal
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
## GrugBot420

Adding GrugBot420 to the Generative AI section.

### Description
GrugBot420 is an open-source AI-powered CLI assistant with neuromorphic intelligence.

### Why it's free
- 100% open source (MIT license)
- Self-hosted - no API costs
- Zero external dependencies
- Built with Bun.js for fast performance

### Features
- 🧠 Neuromorphic AI reasoning
- ⚡ Zero dependencies
- 🔌 Server mode for API access
- 🚀 Cross-platform support
- 💻 Web playground available

### Links
- Repository: https://github.com/grug-group420/grugbot420
- Try it: https://grug-group420.github.io/portal
- Install: `curl -fsSL https://raw.githubusercontent.com/grug-group420/grug-install/main/install.sh | bash`