### PR TITLE
Add ApexToWWW to DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,7 @@ Update Time, five active automations, webhooks.
 
   * [1.1.1.1](https://developers.cloudflare.com/1.1.1.1/) - Free public DNS Resolver, which is fast and secure (encrypt your DNS query), provided by Cloudflare. Useful to bypass your internet provider's DNS blocking, prevent DNS query spying, and [to block adult & malware content](https://developers.cloudflare.com/1.1.1.1/1.1.1.1-for-families). It can also be used [via API](https://developers.cloudflare.com/1.1.1.1/encrypted-dns/dns-over-https/make-api-requests). Note: Just a DNS resolver, not a DNS hoster.
   * [1984.is](https://www.1984.is/product/freedns/) - Free DNS service with API and lots of other free DNS features included.
+  * [ApexToWWW](https://www.apextowww.com/) - Free DNS apex/root/naked domain to www subdomain 301 redirect service. Automatic SSL via Let's Encrypt, IPv6, HTTP/3 support. No account needed, just add two DNS records.
   * [cloudns.net](https://www.cloudns.net/) - Free DNS hosting up to 1 domain with 50 records
   * [deSEC](https://desec.io) - Free DNS hosting with API support, designed with security in mind. Runs on open-source software and is supported by [SSE](https://www.securesystems.de/).
   * [dns.he.net](https://dns.he.net/) - Free DNS hosting service with Dynamic DNS Support


### PR DESCRIPTION
## What is ApexToWWW?

[ApexToWWW](https://www.apextowww.com/) is a free DNS apex/root/naked domain to www subdomain 301 redirect service.

## Why add it?

Many developers need to redirect their apex domain (example.com) to www (www.example.com) because hosting platforms like GitHub Pages, Netlify, and Vercel require CNAME records, which can't be set at the DNS root. ApexToWWW solves this with a free, no-signup service.

## Features (all free, no limits)

- 301 permanent redirect with full path/query preservation
- Automatic SSL via Let's Encrypt
- IPv6 (dual-stack) support
- HTTP/3 (QUIC) support
- No account or signup required
- <50ms redirect latency

## How it works

Users add two DNS records (A + AAAA) to their apex domain, and ApexToWWW handles the redirect automatically.