### PR TITLE
Add BulkPublish to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [BigDataCloud](https://www.bigdatacloud.com/) - Provides fast, accurate, and free (Unlimited or up to 10K-50K/month) APIs for modern web like IP Geolocation, Reverse Geocoding, Networking Insights, Email and Phone Validation, Client Info and more.
   * [Browse AI](https://www.browse.ai) - Extracting and monitoring data on the web. 1k credits per month for free, equals 1k concurrent requests.
   * [BrowserCat](https://www.browsercat.com) - Headless browser API for automation, scraping, AI agent web access, image/pdf generation, and more. Free plan with 1k requests per month.
+  * [BulkPublish](https://www.bulkpublish.com) - Social media publishing API for 11 platforms with scheduling, analytics, and AI agent integration. Free plan includes 5 channels, 30 scheduled posts, and 100 API calls per day.
   * [Calendarific](https://calendarific.com) - Enterprise-grade Public holiday API service for over 200 countries. The free plan includes 500 calls per month.
   * [Canopy](https://www.canopyapi.co/) - GraphQL API for Amazon.com product, search, and category data. The free plan includes 100 calls per month.
   * [CarAPI.dev](https://carapi.dev) - Comprehensive automotive data API with VIN decoding, stolen vehicle checks, vehicle valuation, inspection data, and more. Free tier includes 100 requests/month across all 9 endpoints.


### PR DESCRIPTION
## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy

 * [ ] Large Language Models and other AI tick this box

---

Adding [BulkPublish](https://www.bulkpublish.com) — a social media publishing API that supports 11 platforms from a single endpoint. The free plan includes 5 connected channels, 30 scheduled posts, and 100 API calls per day. Pricing is visible at [bulkpublish.com](https://www.bulkpublish.com).