### PR TITLE
Add cert-depot.com to Security and PKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 
   * [aikido.dev](https://www.aikido.dev) - All-in-one appsec platform covering SCA, SAST, CSPM, DAST, Secrets, IaC, Malware, Container scanning, EOL,... Free plan includes two users, scanning of 10 repos, 1 cloud, 2 containers & 1 domain.
   * [CertKit](https://www.certkit.io/certificate-management) - Manage SSL Certificate issuance, renewal, and monitoring. Search the Certificate Transparency Logs. Free for 3 certificates and 1 user after the beta.
+  * [cert-depot.com](https://cert-depot.com) - Free self-signed SSL/TLS certificate generator. RSA & ECDSA keys, Subject Alternative Names, ZIP & PFX output. No signup, no ads, no limits. Keys are generated in memory and never stored. [Open source](https://github.com/dimastopel/certdepot).
   * [Corgea](https://corgea.com/) - Free autonomous security platform that finds, validates and fixes insecure code and packages across +20 languages and frameworks. Free plan includes 1 user and 2 repos.
   * [crypteron.com](https://www.crypteron.com/) - Cloud-first, developer-friendly security platform prevents data breaches in .NET and Java applications
   * [CyberChef](https://gchq.github.io/CyberChef/) - A simple, intuitive web app for analyzing and decoding/encoding data without dealing with complex tools or programming languages. Like a Swiss army knife of cryptography & encryption. All features are free to use, with no limit. Open source if you wish to self-host.


### PR DESCRIPTION
Add [cert-depot.com](https://cert-depot.com) to the Security and PKI section.

cert-depot.com is a free self-signed SSL/TLS certificate generator:
- 100% free, no signup, no ads, no limits
- RSA 2048/4096 and ECDSA P-256/P-384
- Subject Alternative Names support
- ZIP (PEM files) and PFX (PKCS#12) output
- Keys generated in memory and never stored on the server
- Open source: https://github.com/dimastopel/certdepot