### PR TITLE
Add doloc.io to Translation Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 
   * [AutoLocalise.com](https://www.autolocalise.com/) - Instantly localize without managing translation files. Free for up to 10,000 characters/month, unlimited languages.
   * [crowdin.com](https://crowdin.com/) - Unlimited projects, unlimited strings, and collaborators for Open Source
+  * [doloc.io](https://doloc.io/) - API-first localization for XLIFF, JSON, ARB, Android XML, and Properties. Free forever for up to 200 source texts, with unlimited target languages and translation requests.
   * [Free PO editor](https://pofile.net/free-po-editor) - Free for everybody
   * [Lingo.dev](https://lingo.dev) - Open-source AI-powered CLI for web & mobile localization. Bring your own LLM, or use 10,000 free words every month via Lingo.dev-managed localization engine.
   * [lingohub.com](https://lingohub.com/) - Free up to 3 users, always free for Open Source


### PR DESCRIPTION
## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy
 * [ ] Large Language Models and other AI tick this box

Adds `doloc.io` to `Translation Management`.

`doloc.io` is an API-first localization SaaS for XLIFF, JSON, ARB, Android XML, and Properties. Public pricing is available without signup, and the free forever tier includes up to 200 source texts with unlimited target languages and translation requests.

Pricing: https://doloc.io/pricing/
Legal/contact: https://doloc.io/legal/ and https://doloc.io/imprint/