### PR TITLE
Add AgentsMesh to Generative AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 
 ## Generative AI
 
+  * [AgentsMesh](https://agentsmesh.ai) - AI Agent Workforce Platform for orchestrating AI coding agents (Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode) across remote AI workstations with git worktree isolation and multi-agent channels. The hosted service is free forever with BYOK (bring your own OpenAI/Anthropic/Gemini API key) — no platform fees, no usage caps. [#opensource](https://github.com/AgentsMesh/AgentsMesh)
   * [Arize AX](https://arize.com) - AI engineering platform that helps AI eng/PMs, evaluate, and observe AI applications and agents with built-in Alyx agent. Free product inlcudes 25k spans and ingestion volume of 1gb per month.
   * [Audio Enhancer](https://voice-clone.org/tools/audio-enhancer) - AI-powered audio enhancer SaaS that removes noise and echo while preserving natural vocal clarity. totally Free: unlimited one-click enhancements, no login required, supports MP3/WAV/FLAC
   * [Braintrust](https://www.braintrustdata.com/) - Evals, prompt playground, and data management for Gen AI. Free plan gives upto 1,000 private eval rows/week.


### PR DESCRIPTION
## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy

 * [x] Large Language Models and other AI tick this box

Hosted at agentsmesh.ai. Free forever — you bring your own OpenAI/Anthropic/Gemini API key, the platform itself has no fees and no usage caps. Added alphabetically in Generative AI before Arize AX.