### PR TITLE
Add Snaplert to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [OnlineOrNot.com](https://onlineornot.com/) - OnlineOrNot provides uptime monitoring for websites and APIs, monitoring for cron jobs and scheduled tasks. Also provides status pages. The first five checks with a 3-minute interval are free. The free tier sends alerts via Slack, Discord, and Email.
   * [OntarioNet.ca CN Test](https://cntest.ontarionet.ca) - Check if a website is blocked in China by the Great Firewall. It identifies DNS pollution by comparing DNS results and ASN information detected by servers in China versus servers in the United States.
   * [pagecrawl.io](https://pagecrawl.io/) -  Monitor website changes, free for up to 6 monitors with daily checks.
+  * [Snaplert](https://snaplert.com) - Monitor website changes with visual pixel diffs, AI-powered summaries, and element-level zone picker. Free during open beta — unlimited monitors, 5-minute check intervals.
   * [pagertree.com](https://pagertree.com/) - Simple interface for alerting and on-call management. Free up to 5 users.
   * [phare.io](https://phare.io/) - Uptime Monitoring free for up to 100,000 events for unlimited projets and unlimited status pages.
   * [pingbreak.com](https://pingbreak.com/) - Modern uptime monitoring service. Check unlimited URLs and get downtime notifications via Discord, Slack, or email.


### PR DESCRIPTION
## What

Adds [Snaplert](https://snaplert.com) to the Monitoring section, alongside `pagecrawl.io` which covers the same category (website change monitoring).

## Why it fits free-for-dev

Snaplert is currently in open beta with a **100% free tier** — no credit card, no time limit during beta:
- Unlimited monitors
- 5-minute check intervals
- Email alerts with before/after screenshots
- Visual pixel-level diff overlays
- AI-powered summaries (Claude) explaining what changed
- Element-level zone picker (monitors specific page sections)
- Webhook support (Slack, Discord)

The free-for-dev format requires tools with meaningful free tiers — Snaplert qualifies with unlimited monitors and 5-minute checks during open beta.

## Entry added

```
  * [Snaplert](https://snaplert.com) - Monitor website changes with visual pixel diffs, AI-powered summaries, and element-level zone picker. Free during open beta — unlimited monitors, 5-minute check intervals.
```