### PR TITLE
Add brewpage.app to Web Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,7 @@ Update Time, five active automations, webhooks.
 
   * [Alwaysdata](https://www.alwaysdata.com/) - 1 GB free web hosting with support for MySQL, PostgreSQL, RabbitMQ, .NET, Deno, Elixir, Go, Java, Lua, Node.js, PHP, Python, Ruby, Rust. Custom web servers, access via FTP, WebDAV and SSH. Mailbox, mailing list and app installer included. No custom domain on free plan.
   * [Awardspace.com](https://www.awardspace.com) - Free web hosting + a free short domain, PHP, MySQL, App Installer, Email Sending & No Ads.
+  * [BrewPage](https://brewpage.app) - Free hosting for HTML pages, JSON, key-value pairs, files, and multi-file sites. Short URLs, 15-30 day TTL, owner-token updates, public OpenAPI and MCP server. No account required.
   * [Bubble](https://bubble.io/) - Visual programming to build web and mobile apps without code, free with Bubble branding.
   * [dAppling Network](https://www.dappling.network/) - Decentralized web hosting platform for Web3 frontends focusing on increasing uptime and security and providing an additional access point for users.
   * [DigitalOcean](https://www.digitalocean.com/pricing) - Build and deploy three static sites for free on the App Platform Starter tier.


### PR DESCRIPTION
## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy

 * [ ] Large Language Models and other AI tick this box

## What is free

[brewpage.app](https://brewpage.app) is a free, anonymous publishing service. The free tier covers all functionality (no paid plans exist):

- HTML pages up to 5 MB
- JSON documents up to 1 MB each, 10 000 per collection
- Key-value pairs up to 1 MB each, 1000 keys per namespace
- Files up to 5 MB (video up to 20 MB, audio up to 5 MB)
- Multi-file sites: 100 files, 20 MB total
- Default 15-day TTL, max 30 days, owner-token for later updates
- Public REST API, OpenAPI spec, MCP server (`npx -y brewpage-mcp`)

## Privacy / contact

- Privacy policy: https://brewpage.app/privacy
- Terms: https://brewpage.app/terms
- Contact / abuse: https://brewpage.app/report-abuse

## Where added

Web Hosting section, alphabetically between `BrewPage` and `Bubble` (correctly placed before Bubble since `Br` < `Bu`).