### PR TITLE
updated Vask limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [SuprSend](https://www.suprsend.com/) - SuprSend is a notification infrastructure that streamlines your product notifications with an API-first approach. Create and deliver transactional, crons, and engagement notifications on multiple channels with a single notification API. In free plan you get 10,000 notifications per month, including different workflow nodes such as digests, batches, multi-channels, preferences, tenants, broadcasts and more.
   * [synadia.com](https://synadia.com/ngs) - [NATS.io](https://nats.io) as a service. Global, AWS, GCP, and Azure. Free forever with 4k msg size, 50 active connections, and 5GB of data per month.
   * [webpushr](https://www.webpushr.com/) - Web Push Notifications - Free for upto 10k subscribers, unlimited push notifications, in-browser messaging
-  * [vask](https://vask.dev) - Realtime messaging service, Pusher-compatible. Dev tier is free with 100 concurrent connections, 1,000,000 broadcasts/month, unlimited client events, 32kb message size.
+  * [vask](https://vask.dev) - Realtime messaging service, Pusher-compatible. Dev tier is limited to local development only and free with 100 concurrent connections, 1,000,000 broadcasts/month, unlimited client events, 32kb message size.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
https://github.com/ripienaar/free-for-dev/pull/4359#issuecomment-4410723057

Local Development Only
> Your dev app is restricted to local/dev-safe origins by Vask. When you are ready to go to production, create a new app with your production origins.