### PR TITLE
Add UPCGen - free barcode generator (UPC/EAN/ISBN/FNSKU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,7 +1330,7 @@ Update Time, five active automations, webhooks.
   * [tinypng.com](https://tinypng.com/) - API to compress and resize PNG and JPEG images, offers 500 compressions for free each month
   * [transloadit.com](https://transloadit.com/) - Handles file uploads and encoding of video, audio, images, documents. Free for Open source, charities, and students via the GitHub Student Developer Pack. Commercial applications get 2 GB free for test driving
   * [twicpics.com](https://www.twicpics.com) - Responsive images as a service. It provides an image CDN, a media processing API, and a frontend library to automate image optimization. The service is free for up to 3GB of traffic/per month.
-  * [UPCGen](https://upcgen.com) - Free UPC barcode generator for B2B
+  * [UPCGen](https://upcgen.com) - Free UPC, EAN, ISBN, ITF-14, Code 128, Data Matrix and FNSKU barcode generator for B2B (Amazon, Shopify, etc.). Free tier allows 1 code/24h anonymously or 5 codes/24h with a free account, with CSV/PNG/PDF/SVG/EPS export.
   * [uploadcare.com](https://uploadcare.com/hub/developers/) - Uploadcare provides the media pipeline with the ultimate toolkit based on cutting-edge algorithms. All features are available for developers absolutely for free: File Uploading API and UI, Image CDN and Origin Services, Adaptive Delivery, and Smart Compression. The free tier has 3000 uploads, 3 GB traffic, and 3 GB storage.
   * [VaocherApp QR Code Generator](https://www.vaocherapp.com/qr-code-generator) - Easily create custom QR codes for gift cards, gift vouchers, and promotions. Support custom styling, color, logo...
 

--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,7 @@ Update Time, five active automations, webhooks.
   * [tinypng.com](https://tinypng.com/) - API to compress and resize PNG and JPEG images, offers 500 compressions for free each month
   * [transloadit.com](https://transloadit.com/) - Handles file uploads and encoding of video, audio, images, documents. Free for Open source, charities, and students via the GitHub Student Developer Pack. Commercial applications get 2 GB free for test driving
   * [twicpics.com](https://www.twicpics.com) - Responsive images as a service. It provides an image CDN, a media processing API, and a frontend library to automate image optimization. The service is free for up to 3GB of traffic/per month.
+  * [UPCGen](https://upcgen.com) - Free UPC barcode generator for B2B
   * [uploadcare.com](https://uploadcare.com/hub/developers/) - Uploadcare provides the media pipeline with the ultimate toolkit based on cutting-edge algorithms. All features are available for developers absolutely for free: File Uploading API and UI, Image CDN and Origin Services, Adaptive Delivery, and Smart Compression. The free tier has 3000 uploads, 3 GB traffic, and 3 GB storage.
   * [VaocherApp QR Code Generator](https://www.vaocherapp.com/qr-code-generator) - Easily create custom QR codes for gift cards, gift vouchers, and promotions. Support custom styling, color, logo...
 


### PR DESCRIPTION
Adds [UPCGen](https://upcgen.com) to the **Storage and Media Processing** section, placed alphabetically between `twicpics.com` and `uploadcare.com`.

UPCGen is a free barcode generator (UPC, EAN, ISBN, ITF-14, Code 128, Data Matrix, FNSKU) aimed at e-commerce sellers (Amazon, Shopify, etc.).

**Free tier:** 1 code per 24h anonymously, or 5 codes per 24h with a free account. Exports to CSV, PNG, PDF, SVG, and EPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)