### PR TITLE
Add Domain Intelligence API to APIs, Data, and ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Compare JSON](https://comparejson.com) - An online tool for comparing differences between two JSON data structures, helping you quickly locate the differences in JSON data.
   * [Disease.sh](https://disease.sh/) - A free API providing accurate data for building the Covid-19 related useful Apps.
   * [Doczilla](https://www.doczilla.app/) - SaaS API empowering the generation of screenshots or PDFs directly from HTML/CSS/JS code. The free plan allows 250 documents month.
+  * [Domain Intelligence API](https://oti-labs.com/domain-intelligence-api) - Aggregate DNS, WHOIS/RDAP, SSL, subdomain enumeration (CT logs + DNS bruteforce), and SPF/DMARC/DKIM posture in a single REST call. Free tier: 1,000 requests/month, no credit card required.
   * [Doppio](https://doppio.sh/) - Managed API to generate and privately store PDFs and Screenshots using top rendering technology. The free plan allows 400 PDFs and Screenshots per month.
   * [drawDB](https://drawdb.app/) - Free and open-source online database diagram editor with no signup required.
   * [DynamicDocs](https://advicement.io) - Generate PDF documents with JSON to PDF API based on LaTeX templates. The free plan allows 50 API calls per month and access to a library of templates.


### PR DESCRIPTION
Adding Domain Intelligence API — free-tier REST API for aggregated domain data (WHOIS/RDAP, DNS, SSL, subdomain enumeration, email security). 1,000 requests/month free, no credit card required. Public MIT-licensed source: https://github.com/osiris-technical-institute/domain-intelligence-api