### PR TITLE
Add Helium MCP to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [FraudLabs Pro](https://www.fraudlabspro.com) - Screen an order transaction for credit card payment fraud. This REST API will detect all possible fraud traits based on the input parameters of an order. The Free Micro plan has 500 transactions per month.
   * [FreeIPAPI](https://freeipapi.com) - Free, Fast and Reliable IP Geolocation API for commercial and non-commercial users available in JSON
   * [Geolocated.io](https://geolocated.io) - IP Geolocation API with multi-continent servers, offering a free plan with 2,000 requests per day.
+  * [Helium MCP](https://heliumtrades.com/mcp-page/) - Free REST + MCP API combining ML-derived options pricing (fair value, prob_ITM, Greeks) with structured news intelligence (3.2M+ articles, 31-dimension bias scoring). 10 endpoints, JSON in/out. Free tier: 50 queries per IP, no signup. MCP-compatible with Claude Desktop, Cursor, Windsurf.
   * [Hex](https://hex.tech/) - a collaborative data platform for notebooks, data apps, and knowledge libraries. Free community tier with up to five projects.
   * [Hook0](https://www.hook0.com/) - Hook0 is an open-source Webhooks-as-a-service (WaaS) that makes it easy for online products to provide webhooks. Dispatch up to 100 events/day with seven days of history retention for free.
   * [Hoppscotch](https://hoppscotch.io) - A free, fast, and beautiful API request builder.


### PR DESCRIPTION
Adding Helium MCP — a free REST + MCP API combining ML options pricing with structured news intelligence. Inserted alphabetically before "Hex".

## Why it fits

- **Free tier**: 50 queries per IP, no signup, no API key required
- **What it provides**:
  - ML options pricing: per-symbol fair value, prob_ITM, Greeks
  - 31-dimension news-bias scoring across 3.2M+ articles
  - Real-time market data, ranked options strategies, semantic meme search
- **Two ways to call it**:
  - Plain REST: `curl https://heliumtrades.com/mcp_search/?q=apple+earnings&limit=3`
  - MCP server: `https://heliumtrades.com/mcp` (Claude Desktop, Cursor, Windsurf)

Source: https://github.com/connerlambden/helium-mcp. Page: https://heliumtrades.com/mcp-page/

Let me know if there's a better section — could also fit under Generative AI given the MCP / AI assistant integration angle.