### PR TITLE
Add Vaultool to Miscellaneous section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1611,6 +1611,7 @@ Update Time, five active automations, webhooks.
   * [SurveyMonkey.com](https://www.surveymonkey.com) - Create online surveys. Analyze the results online. The free plan allows only 10 questions and 100 responses per survey.
   * [SYNCDATE](https://syncdate.app) - Two-way Google Calendar sync. Free tier: 2 accounts, unlimited events.
   * [UUID Generator](https://newuuid.com/) - Generate UUID v1, UUID v4, UUID v7, GUID, Nil UUIDs, CUID v1/v2, NanoID, and ULID instantly with enterprise-grade
+  * [Vaultool](https://vaultool.com) - Free online tools suite (50+ tools) with client-side processing for privacy. No registration required.
   * [Versionfeeds](https://versionfeeds.com) - Custom RSS feeds for releases of your favorite software. Have the latest versions of your programming languages, libraries, or loved tools in one feed. (The first 3 feeds are free)
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
## Description

Add [Vaultool](https://vaultool.com) to the Miscellaneous section of free-for-dev.

Vaultool is a free online tools suite with 50+ tools for developers, designers, and office productivity. Key features:
- All tools run client-side in the browser — no data ever leaves the user's device
- No registration required
- Covers JSON formatting, PDF tools, image processing, text utilities, and more

This is a genuinely free tool that respects user privacy, fitting perfectly with the free-for-dev philosophy.