### PR TITLE
Add cv.cm

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [cally.com](https://cally.com/) - Find the perfect time and date for a meeting. Simple to use, works great for small and large groups.
   * [cDox](https://cdox.ca) - Private document editor hosted in Canada. Write, format, collaborate, and publish documents with clean public links. Data is never used for AI training. Free plan includes 50 MB storage, up to 3 public links, and export to PDF, Word, and Markdown.
   * [Chanty.com](https://chanty.com/) - Chanty is another alternative to Slack. It has a free forever plan for small teams (up to 10) with unlimited public and private conversations, searchable history, unlimited 1:1 audio calls, unlimited voice messages, ten integrations, and 20 GB storage per team.
+  * [cv.cm](https://cv.cm/) - Free online clipboard and pastebin alternative. Paste text, images, or files and share via a short link, no signup. Free tier for everyday use; paid plans add long-term storage. Includes an open API.
   * [DevToolLab](https://devtoollab.com) - Online developer tools offering free access to all basic tools, with the ability to auto save one entry per tool, standard processing speed, and community support.
   * [Discord](https://discord.com/) - Chat with public/private rooms. Markdown text, voice, video, and screen sharing capabilities. Free for unlimited users.
   * [Dubble](https://dubble.so/) - Free Step-by-Step Guide creator. Take screenshots, document processes and colloborate with your team. Also supports async screen recording.


### PR DESCRIPTION
## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy

cv.cm is a hosted online clipboard / pastebin alternative. You paste text, images or files and get a short link to share or move content between devices — no signup needed. The free tier covers everyday use; paid plans add long-term storage. Pricing is public at https://cv.cm/pricing, the privacy policy is at https://cv.cm/privacy, and the team is reachable at m@cv.cm. Added alphabetically under Tools for Teams and Collaboration.