### PR TITLE
Add EventDock to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [drawDB](https://drawdb.app/) - Free and open-source online database diagram editor with no signup required.
   * [DynamicDocs](https://advicement.io) - Generate PDF documents with JSON to PDF API based on LaTeX templates. The free plan allows 50 API calls per month and access to a library of templates.
   * [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API. Free tier includes 15 requests per minute.
+  * [EventDock](https://eventdock.app) - Webhook reliability for developers: automatic retries, dead-letter queue, and one-click replay for incoming webhooks. The free tier includes 5,000 events per month and 3 endpoints, no credit card required.
   * [Export SDK](https://exportsdk.com) - PDF generator API with drag-and-drop template editor that provides an SDK and no-code integrations. The free plan has 250 monthly pages, unlimited users, and three templates.
   * [ExtendsClass](https://extendsclass.com/rest-client-online.html) - Free web-based HTTP client to send HTTP requests.
   * [Financial Data](https://financialdata.net/) - Stock market and financial data API. Free plan allows 300 requests per day.


### PR DESCRIPTION
Adds EventDock — a webhook reliability service (automatic retries, dead-letter queue, and one-click replay for incoming webhooks).

Free tier: 5,000 events/month and 3 endpoints, no credit card required. The free tier is permanent (not a time-limited trial), so it meets the eligibility rules in the README NOTE. TLS is available on all tiers including free.

Placed alphabetically in the "APIs, Data, and ML" section alongside other webhook-as-a-service offerings (Svix, Hook0, Posthook).