### PR TITLE
Add PDFPipe - HTML-to-PDF API with free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Parseur](https://parseur.com) - 20 free pages/month: Extract data from PDFs, emails. AI powered. Full API access.
   * [PDF-API.io](https://pdf-api.io) - PDF Automation API, visual template editor or HTML to PDF, dynamic data integration, and PDF rendering with an API. The free plan comes with one template, 100 PDFs/month.
   * [PDFBolt](https://pdfbolt.com) - Developer-focused PDF generation API designed with privacy in mind. It offers Stripe-inspired documentation and includes 500 free PDF conversions per month.
+  * [PDFPipe](https://pdfpipe.xyz) - HTML-to-PDF API. 500 documents/month free, no credit card required. Send HTML or a URL, get a PDF back.
   * [Pixela](https://pixe.la/) - Free daystream database service. All operations are performed by API. Visualization with heat maps and line graphs is also possible.
   * [Posthook](https://posthook.io) - Schedule webhooks to fire at a future time with automatic retries, delivery tracking, and failure alerting. Free plan includes 1,000 webhooks per month.
   * [Postman](https://postman.com) - Simplify workflows and create better APIs - faster - with Postman, a collaboration platform for API development. Use the Postman App for free forever. Postman cloud features are also free forever with certain limits.


### PR DESCRIPTION
## What is PDFPipe?

[PDFPipe](https://pdfpipe.xyz) is an HTML-to-PDF conversion API. Send HTML markup or a URL and receive a PDF in return.

**Free tier:** 500 documents/month, no credit card required.

## Entry added

Added to the **APIs, Data, and ML** section in alphabetical order (between PDFBolt and Pixela):

```
* [PDFPipe](https://pdfpipe.xyz) - HTML-to-PDF API. 500 documents/month free, no credit card required. Send HTML or a URL, get a PDF back.
```