### PR TITLE
Add HackMyIP to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [FraudLabs Pro](https://www.fraudlabspro.com) - Screen an order transaction for credit card payment fraud. This REST API will detect all possible fraud traits based on the input parameters of an order. The Free Micro plan has 500 transactions per month.
   * [FreeIPAPI](https://freeipapi.com) - Free, Fast and Reliable IP Geolocation API for commercial and non-commercial users available in JSON
   * [Geolocated.io](https://geolocated.io) - IP Geolocation API with multi-continent servers, offering a free plan with 2,000 requests per day.
+  * [HackMyIP](https://hackmyip.com/api-docs) - Free IP and network data API: IP geolocation, DNS records, and RDAP WHOIS lookups. JSON, no API key, no signup, 60 requests/minute.
   * [Hex](https://hex.tech/) - a collaborative data platform for notebooks, data apps, and knowledge libraries. Free community tier with up to five projects.
   * [Hook0](https://www.hook0.com/) - Hook0 is an open-source Webhooks-as-a-service (WaaS) that makes it easy for online products to provide webhooks. Dispatch up to 100 events/day with seven days of history retention for free.
   * [Hoppscotch](https://hoppscotch.io) - A free, fast, and beautiful API request builder.


### PR DESCRIPTION
Adds [HackMyIP](https://hackmyip.com/api-docs), a free IP and network data API.

- IP geolocation, DNS records, and RDAP WHOIS lookups
- JSON responses, no API key, no signup
- 60 requests/minute

One entry, alphabetical placement in the **APIs, Data, and ML** section. HTTPS link, no trailing slash.