### PR TITLE
Add VeriRoute Intel (phone number intelligence API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,6 +1501,7 @@ Update Time, five active automations, webhooks.
 
   * [numverify](https://numverify.com/) - Global phone number validation and lookup JSON API. 100 API requests/month
   * [veriphone](https://veriphone.io/) - Global phone number verification in a free, fast, reliable JSON API. 1000 requests/month
+  * [VeriRoute Intel](https://verirouteintel.com/) - CNAM caller ID, carrier/LRN lookup and spam scoring for US/Canada phone numbers. Free carrier (LRN) lookups on unfunded accounts
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adds [VeriRoute Intel](https://verirouteintel.com) to the International Mobile Number Verification API and SDK section.

- CNAM caller ID, carrier/LRN lookup, and spam/trust scoring for US/Canada (NANP) numbers
- Free tier: carrier (LRN) lookups are free on unfunded accounts; web tool allows free lookups without an account
- Docs: https://verirouteintel.com/api-docs — OpenAPI spec, Python and Node SDKs

Disclosure: I operate this service.