### PR TITLE
Add InfraNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Hoppscotch](https://hoppscotch.io) - A free, fast, and beautiful API request builder.
   * [HS Ping](https://hsping.com) - A multi-country HS (Harmonized System) and HTS (Harmonized Tariff System) code lookup API, with a free plan offering 100 lookups/day.
   * [huggingface.co](https://huggingface.co) - Build, train, and deploy NLP models for Pytorch, TensorFlow, and JAX. Free up to 30k input characters/mo.
+  * [InfraNode](https://infranode.dev) - Unified REST API for German city infrastructure data (weather, air quality, water levels, EV chargers, live public transport) from 35+ official sources. Free: no key required for 60 requests/min, free key for higher limits.
   * [Insomnia](https://insomnia.rest) - Open-source API client for designing and testing APIs, it supports REST and GraphQL
   * [Invantive Cloud](https://cloud.invantive.com/) - Access over 70 (cloud)platforms such as Exact Online, Twinfield, ActiveCampaign or Visma using Invantive SQL or OData4 (typically Power BI or Power Query). Includes data replication and exchange. Free plan for developers and implementation consultants. Free for specific platforms with limitations in data volumes.
   * [IP Geolocation API by ipwho.org](https://ipwho.org/) - 2,000 free requests per day. Fast, enterprise grade API at non-enterprise prices. Trusted by developers, corporate, government and education clients. Servers in 12+ regions.


### PR DESCRIPTION
Adds InfraNode to the APIs, Data, and ML section (alphabetical order, between huggingface.co and Insomnia).

InfraNode (https://infranode.dev) is a unified REST API for German city infrastructure data (weather, air quality, water levels, EV chargers, live public transport with delays, demographics) aggregated from 35+ official sources. 84 cities, 48 endpoints.

Free tier details: no API key required for 60 requests/min, free key available for higher limits. HTTPS supported. Documentation in German and English.

Generated with [Claude Code](https://claude.com/claude-code)