### PR TITLE
Add Pick an Agency to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Parseur](https://parseur.com) - 20 free pages/month: Extract data from PDFs, emails. AI powered. Full API access.
   * [PDF-API.io](https://pdf-api.io) - PDF Automation API, visual template editor or HTML to PDF, dynamic data integration, and PDF rendering with an API. The free plan comes with one template, 100 PDFs/month.
   * [PDFBolt](https://pdfbolt.com) - Developer-focused PDF generation API designed with privacy in mind. It offers Stripe-inspired documentation and includes 500 free PDF conversions per month.
+  * [Pick an Agency](https://www.pickanagency.com/developers) - Free REST API and MCP server over a directory of 47,000+ verified marketing agencies: search by service, location, industry and rating, fetch profiles with client reviews, or get a ranked shortlist from a brief. No API key required, CORS enabled.
   * [Pixela](https://pixe.la/) - Free daystream database service. All operations are performed by API. Visualization with heat maps and line graphs is also possible.
   * [Posthook](https://posthook.io) - Schedule webhooks to fire at a future time with automatic retries, delivery tracking, and failure alerting. Free plan includes 1,000 webhooks per month.
   * [Postman](https://postman.com) - Simplify workflows and create better APIs - faster - with Postman, a collaboration platform for API development. Use the Postman App for free forever. Postman cloud features are also free forever with certain limits.


### PR DESCRIPTION
Adds **Pick an Agency** to the APIs, Data, and ML section (alphabetical order kept).

- Free, read-only REST API over a directory of 47,000+ verified marketing agencies (129,000+ indexed)
- Entirely free: no API key, no signup, no paid tier — CORS enabled
- Docs: https://www.pickanagency.com/developers · OpenAPI 3.1: https://www.pickanagency.com/api/v1/openapi.json
- Also exposes an MCP server for AI agents (listed on the official MCP registry)
- Try: `curl "https://www.pickanagency.com/api/v1/search?service=SEO&city=Berlin&limit=3"`

Disclosure: I'm the founder.