### PR TITLE
Add WardenPoint to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [UptimeObserver.com](https://uptimeobserver.com) - Get 20 uptime monitors with 5-minute intervals and a customizable status page-even for commercial use. Enjoy unlimited, real-time notifications via email and Telegram. No credit card needed to get started.
   * [uptimetoolbox.com](https://uptimetoolbox.com/) - Free monitoring for five websites, 3-minute intervals, public statuspage.
   * [Wachete](https://www.wachete.com) - monitor five pages, checks every 24 hours.
+  * [WardenPoint](https://wardenpoint.com) - Incident alerting and on-call escalation. Free tier: Telegram (text, voice messages, VoIP calls that ring through DND), email, Slack, Teams, WhatsApp, Viber and webhook alerts with escalation chains and audit log — 200 notifications/month, 5 recipients, no credit card.
   * [Xitoring.com](https://xitoring.com/) - Uptime monitoring: 20 free, Linux and Windows Server monitoring: 5 free, Status page: 1 free - Mobile app, multiple notification channel, and much more!
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
Adds WardenPoint — incident-alerting & on-call escalation SaaS — to the Monitoring section. It has a genuine forever-free tier (no credit card): Telegram / email / Slack / Teams / WhatsApp / Viber / webhook alerts with acknowledgement-aware escalation chains and an audit log, 200 notifications/month and 5 recipients. Fits alongside the existing on-call/alerting entries (Better Stack, PagerTree, Runframe). Single-line addition, alphabetical order kept.