### PR TITLE
Add Invovate (free invoice generation API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1521,6 +1521,7 @@ Update Time, five active automations, webhooks.
   * [Exchange Rate API](https://exchange-rateapi.com) - Real-time currency rates for 160+ currencies with 60-second updates and official SDKs. Free tier includes 300 requests/month.
   * [FraudLabsPRO](https://www.fraudlabspro.com) - Help merchants to prevent payment fraud and chargebacks. Free Micro Plan available with 500 queries/month.
   * [FxRatesAPI](https://fxratesapi.com) - Provides real-time and historical exchange rates. The free tier requires attribution.
+  * [Invovate](https://invovate.com/api) - REST API to generate professional PDF, JSON, and UBL invoices in 11 languages with VAT/tax support. Free tier offers 40 requests/hour, 400/week.
   * [Moesif API Monetization](https://www.moesif.com/) - Generate revenue from APIs via usage-based billing. Connect to Stripe, Chargebee, etc. The free tier offers 30,000 events/month.
   * [ParityVend](https://www.ambeteco.com/ParityVend/) - Automatically adjust pricing based on visitor location to expand your business globally and reach new markets (purchasing power parity). The free plan includes 7,500 API requests/month.
   * [Qonversion](http://qonversion.io/) - All-in-one cross-platform subscription management platform offering analytics, A/B testing, Apple Search Ads, remote configs, and growth tools for optimizing in-app purchases and monetization. Compatible with iOS, Android, React Native, Flutter, Unity, Cordova, Stripe, and web. Free up to $10k in monthly tracked revenue.


### PR DESCRIPTION
Adds **Invovate** under *Payment and Billing Integration* (alphabetical, after FxRatesAPI).

Invovate is a REST API that generates professional PDF, JSON, and UBL invoices in 11 languages with VAT/tax support. It has a genuine free developer tier: **40 requests/hour, 400/week** with a free API key — no paid plan required to build and test.

- API docs: https://invovate.com/api
- Free tier confirmed (40/hr, 400/wk)
- One entry, follows the existing format/category.