### PR TITLE
Add GeneTech Knowledge Engine — 12 domain free science API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Feature Toggles Management Platforms](#feature-toggles-management-platforms)
   * [Font](#font)
   * [Forms](#forms)
+  * [GeneTech Knowledge Engine](https://genetech.tools) - 12 domain science knowledge base API with 4,000+ structured entities (genes, quantum, nuclear, brain, deep-sea, etc.). Free tier: 30 calls/hour, no signup. MCP-compatible.
   * [Generative AI](#generative-ai)
   * [IaaS](#iaas)
   * [IDE and Code Editing](#ide-and-code-editing)


### PR DESCRIPTION
GeneTech Knowledge Engine provides 12 frontier science knowledge bases with 4,000+ structured JSON entities via free REST API.

**Free tier:** 30 calls/hour, no signup needed.
**12 domains:** Gene Technology (422), Life Science (511), New Energy (492), Agent Ecosystem (433), Brain Science (347), Quantum (317), Nuclear (260), Exo-Science (336), Deep-Sea (322), Alien Minerals (283), Robot Parts (247).

**Try it:**
```bash
curl https://genetech-tools.pages.dev/api/entities.json | jq .total
```

- Website: https://genetech.tools
- GitHub: https://github.com/lm203688/kb-ecosystem
- MCP server: `npx @frontierkb/mcp-server`

Added to APIs, Data, and ML section.