### PR TITLE
Add StealthHumanizer to Generative AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,6 +999,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Portkey](https://portkey.ai/) - Control panel for Gen AI apps featuring an observability suite & an AI gateway. Send & log up to 10,000 requests for free every month.
   * [ReportGPT](https://ReportGPT.app) - AI Powered Writing Assistant. The entire platform is free as long as you bring your own API key.
   * [Zenable](https://zenable.io) - Instantly auto-fix outputs from tools like Cursor, Windsurf, and Copilot to meet your company's quality and compliance standards using guardrails built with Policy as Code. The free tier includes 100 tools calls per day to the MCP server and 25 free automated pull request reviews per day via the GitHub App.
+  * [StealthHumanizer](https://stealthhumanizer.vercel.app/) - Free open-source AI text humanizer that works with 35+ AI providers. No login, no limits. Supports 16+ languages with multi-pass humanization. [#opensource](https://github.com/rudra496/StealthHumanizer)
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Added StealthHumanizer — a free, open-source AI text humanizer to the Generative AI section.

- **What:** AI text humanizer with 35+ providers, 16+ languages, multi-pass ninja mode
- **Free tier:** Completely free, no login required, no limits
- **Open source:** https://github.com/rudra496/StealthHumanizer (MIT license)
- **Live:** https://stealthhumanizer.vercel.app/

No paid plans, no freemium — fully free and open source.