### PR TITLE
Add BrandIcons to Design and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,6 +1336,7 @@ Update Time, five active automations, webhooks.
 ## Design and UI
 
   * [BoxySVG](https://boxy-svg.com) - A free installable Web app for drawing SVGs and exporting in SVG, PNG, jpeg, and other formats.
+  * [BrandIcons](https://brandicons.dev) - Brand/favicon icon for any domain from a single URL, with an AI fallback for brands that have no live site. Free tier: 500,000 requests/month.
   * [Calendar Icons Generator](https://calendariconsgenerator.app/) - Generate an entire year's worth of unique icons in a single click, absolutely FREE
   * [Canva](https://canva.com) - Free online design tool to create visual content.
   * [CodedThemes](https://codedthemes.com/) - Offers a well-crafted admin dashboard & and UI kits designed to simplify and speed up modern web development.


### PR DESCRIPTION
Adds **BrandIcons** under *Design and UI*, alongside the other logo/icon API (Logo.dev).

- **Service:** https://brandicons.dev — returns a clean brand/favicon icon for any domain from a single URL.
- **Free tier (not a trial):** Community plan — 500,000 requests/month, no card required. Meets the free-tier requirement.
- **TLS:** available on all tiers (not paid-only).

One entry, placed alphabetically.