### PR TITLE
Add DomainIntel API to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Compare JSON](https://comparejson.com) - An online tool for comparing differences between two JSON data structures, helping you quickly locate the differences in JSON data.
   * [Disease.sh](https://disease.sh/) - A free API providing accurate data for building the Covid-19 related useful Apps.
   * [Doczilla](https://www.doczilla.app/) - SaaS API empowering the generation of screenshots or PDFs directly from HTML/CSS/JS code. The free plan allows 250 documents month.
+  * [DomainIntel API](https://domainintel.onrender.com) - Free domain intelligence API: RDAP registration data, DNS-over-HTTPS records, certificate transparency logs, and bulk parallel lookups. Free tier: 500 requests/month.
   * [Doppio](https://doppio.sh/) - Managed API to generate and privately store PDFs and Screenshots using top rendering technology. The free plan allows 400 PDFs and Screenshots per month.
   * [drawDB](https://drawdb.app/) - Free and open-source online database diagram editor with no signup required.
   * [DynamicDocs](https://advicement.io) - Generate PDF documents with JSON to PDF API based on LaTeX templates. The free plan allows 50 API calls per month and access to a library of templates.


### PR DESCRIPTION
Added DomainIntel API to the "APIs, Data, and ML" section.

DomainIntel provides free RDAP registration data, DNS-over-HTTPS, certificate transparency logs, and bulk parallel lookups. Free tier: 500 requests/month.

🤖 Generated with Neo