### PR TITLE
Add ToolNest - 67+ free online developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1621,6 +1621,7 @@ Update Time, five active automations, webhooks.
   * [superfeedr.com](https://superfeedr.com/) - Real-time PubSubHubbub compliant feeds, export, analytics. Free with less customization
   * [SurveyMonkey.com](https://www.surveymonkey.com) - Create online surveys. Analyze the results online. The free plan allows only 10 questions and 100 responses per survey.
   * [SYNCDATE](https://syncdate.app) - Two-way Google Calendar sync. Free tier: 2 accounts, unlimited events.
+  * [ToolNest](https://nguyenminhduc9988.github.io/free-tools-hub/) - 67+ free online developer tools: JSON formatter, Base64 encoder/decoder, password generator, QR code generator, regex tester, hash generator, color converter, and more. 100% client-side, no signup required.
   * [UUID Generator](https://newuuid.com/) - Generate UUID v1, UUID v4, UUID v7, GUID, Nil UUIDs, CUID v1/v2, NanoID, and ULID instantly with enterprise-grade
   * [Versionfeeds](https://versionfeeds.com) - Custom RSS feeds for releases of your favorite software. Have the latest versions of your programming languages, libraries, or loved tools in one feed. (The first 3 feeds are free)
 


### PR DESCRIPTION
## What

Adding [ToolNest](https://nguyenminhduc9988.github.io/free-tools-hub/) to the Miscellaneous section.

## Why

ToolNest provides 67+ free, client-side developer tools including:
- JSON formatter/validator
- Base64 encoder/decoder
- Password generator
- QR code generator
- Regex tester
- Hash generator (MD5, SHA1, SHA256, SHA512)
- Color converter (HEX/RGB/HSL)
- SQL formatter
- JWT decoder
- Unit converter
- And 50+ more

All tools are 100% browser-based with no data sent to servers, no signup required, and fully responsive.

## Type of Change
- [x] New tool/service added under Miscellaneous section

## Verification
- Site is live: https://nguyenminhduc9988.github.io/free-tools-hub/
- All tools work client-side with no server dependency
- No registration or payment required
- Open source: https://github.com/nguyenminhduc9988/free-tools-hub