### PR TITLE
Add Image to Base64 tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1607,6 +1607,7 @@ Update Time, five active automations, webhooks.
   * [FOSSA](https://fossa.com/) - Scalable, end-to-end management for third-party code, license compliance and vulnerabilities.
   * [Hook Relay](https://www.hookrelay.dev/) - Add webhook support to your app without the hassles: done-for-you queueing, retries with backoff, and logging. The free plan has 100 deliveries per day, 14-day retention, and 3 hook endpoints.
   * [Hosting Checker](https://hostingchecker.co) - Check hosting information such as ASN, ISP, location and more for any domain, website or IP address. Also includes multiple hosting and DNS-related tools.
+  * [Image to Base64](https://image2base64.com) - Free, 100% client-side tool to convert PNG, JPG, SVG, WebP and GIF images into Base64 strings and data URIs. No upload, no sign-up; everything runs in your browser.
   * [newreleases.io](https://newreleases.io/) - Receive notifications on email, Slack, Telegram, Discord, and custom webhooks for new releases from GitHub, GitLab, Bitbucket, Python PyPI, Java Maven, Node.js NPM, Node.js Yarn, Ruby Gems, PHP Packagist, .NET NuGet, Rust Cargo and Docker Hub.
   * [PDFMonkey](https://www.pdfmonkey.io/) - Manage PDF templates in a dashboard, call the API with dynamic data, and download your PDF. Offers 300 free documents per month.
   * [Pika Code Screenshots](https://pika.style/templates/code-image) - Create beautiful, customizable screenshots from code snippets and VSCode using the extension.


### PR DESCRIPTION
## What is this?

Adds [Image to Base64](https://image2base64.com) to the **Miscellaneous** section.

## About the tool

A free, 100% client-side tool to convert PNG, JPG, SVG, WebP and GIF images into Base64 strings and data URIs. No upload, no sign-up — everything runs in the browser via the FileReader API. Also supports Base64-to-Image decoding.

## Why it fits

- Completely free, no tier limitations
- Privacy-focused: files never leave the user's browser
- Useful for developers working with data URIs, HTML/CSS snippets, and small-asset inline workflows