### PR TITLE
Add InfraNode (free keyless German city open-data API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Hoppscotch](https://hoppscotch.io) - A free, fast, and beautiful API request builder.
   * [HS Ping](https://hsping.com) - A multi-country HS (Harmonized System) and HTS (Harmonized Tariff System) code lookup API, with a free plan offering 100 lookups/day.
   * [huggingface.co](https://huggingface.co) - Build, train, and deploy NLP models for Pytorch, TensorFlow, and JAX. Free up to 30k input characters/mo.
+  * [InfraNode](https://infranode.dev) - Open REST API and remote MCP server for German city open data: 84 cities, 60+ data types (weather, air quality, transit realtime, parking, EV charging, water levels, solar, statistics). Completely free, no API key and no registration required. Every response carries the upstream license and attribution.
   * [Insomnia](https://insomnia.rest) - Open-source API client for designing and testing APIs, it supports REST and GraphQL
   * [Invantive Cloud](https://cloud.invantive.com/) - Access over 70 (cloud)platforms such as Exact Online, Twinfield, ActiveCampaign or Visma using Invantive SQL or OData4 (typically Power BI or Power Query). Includes data replication and exchange. Free plan for developers and implementation consultants. Free for specific platforms with limitations in data volumes.
   * [IP Geolocation API by ipwho.org](https://ipwho.org/) - 2,000 free requests per day. Fast, enterprise grade API at non-enterprise prices. Trusted by developers, corporate, government and education clients. Servers in 12+ regions.


### PR DESCRIPTION
This PR adds InfraNode to the "APIs, Data, and ML" section (inserted in alphabetical order, existing list format).

- What it is: an open REST API (plus a remote MCP server for AI agents) that normalizes German public-infrastructure open data behind one interface: 84 cities, 60+ data types such as weather (DWD), air quality (UBA), public transit realtime departures, parking occupancy, EV charging, water levels, solar potential and demographic statistics.
- Free tier: everything is free. There is no paid tier, no API key and no registration; every endpoint is publicly callable.
- Openness: the code is open source under Apache-2.0 (https://github.com/street1983nk/infranode). Data keeps the licenses of its official upstream sources; every response carries license and attribution.
- Docs: https://infranode.dev (OpenAPI spec at https://infranode.dev/api/v1/openapi.yaml)