### PR TITLE
Add Billotter to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,6 +1605,7 @@ Update Time, five active automations, webhooks.
 
 ## Miscellaneous
 
+  * [Billotter](https://billotter.com/) - In-browser invoice, estimate and quote generator with PDF export — no signup, no backend, invoice data never leaves the browser. Free without limits; optional one-time Pro unlock for workflow extras.
   * [BinShare.net](https://binshare.net) - Create & share code or binaries. Available to share as a beautiful image e.g. for Twitter / Facebook post or as a link e.g. for chats or forums.
   * [Blynk](https://blynk.io) - A SaaS with API to control, build & evaluate IoT devices. Free Developer Plan with 5 devices, Free Cloud & data storage. Mobile Apps are also available.
   * [cron-job.org](https://cron-job.org) - Online cronjobs service. Unlimited jobs are free of charge.


### PR DESCRIPTION
Adds [Billotter](https://billotter.com/) to the Miscellaneous section (alphabetical position, before BinShare.net).

**What it is:** a free in-browser invoice/estimate/quote/receipt generator. Single static page — no signup, no backend, no analytics; invoice data lives in localStorage and never leaves the browser (verifiable in the network tab). PDF export via print CSS, 26 currencies, niche templates.

**Free tier:** the entire generator is free without limits, permanently (not a trial). There's an optional one-time $9 unlock for workflow extras (client book, item library, pay-by-QR), which is disclosed in the entry.

**Disclosure:** I'm the author of the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)