### PR TITLE
Add AlphaAI to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 ## APIs, Data, and ML
 
   * [Abstract API](https://www.abstractapi.com) - API suite for various use cases, including IP geolocation, phone number validation, or email validation.
+  * [AlphaAI](https://alphai.io/developers) - Financial news pre-analyzed per ticker with a 1-10 relevance score, category, and impact, plus SEC Form 4 insider data, over REST and MCP. Free tier: 20 requests/min and 100 requests/day, no credit card.
   * [Apify](https://www.apify.com/) - Web scraping and automation platform to create an API for any website and extract data. Ready-made scrapers, integrated proxies, and custom solutions. Free plan with $5 platform credits included every month.
   * [APITemplate.io](https://apitemplate.io) - Auto-generate images and PDF documents with a simple API or automation tools like Zapier & Airtable. No CSS/HTML is required. The free plan comes with 50 images/month and three templates.
   * [APIVerve](https://apiverve.com) - Get instant access to over 120+ APIs for free, built with quality, consistency, and reliability in mind. The free plan covers up to 50 API Tokens per month. (Possibly taken down, 2025-06-25)


### PR DESCRIPTION
Adds **AlphaAI** to *APIs, Data, and ML*, placed alphabetically (between Abstract API and Apify).

- **What it is:** financial-news API — every article is pre-analyzed at ingest with a per-ticker relevance score (1–10), category, and impact; SEC Form 4 insider filings are included as structured data. REST + MCP.
- **Free tier (permanent, not a trial, no credit card):** 20 requests/min and 100 requests/day.
- Fits alongside existing entries like *Earnings Feed*, *Financial Data*, and *News API*.
- Docs / playground: https://alphai.io/developers