### PR TITLE
Add VibeKit.bot to Code Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 * [Metalama](https://www.postsharp.net/metalama) - A C#-specific tool that generates boilerplate code on the fly during compilation to keep source code clean. It is free for open-source projects; its commercial-friendly free tier includes up to three aspects.
 * [Supermaven](https://www.supermaven.com/) - A high-speed AI code completion plugin for VS Code, JetBrains, and Neovim. The free tier provides unlimited inline completions with a focus on ultra-low latency.
 * [v0.dev](https://v0.dev/) - Created by Vercel, v0 generates copy-and-paste friendly React code using shadcn/ui and Tailwind CSS. It uses a credit system, providing 1,200 starting credits and 200 free credits monthly.
+* [VibeKit.bot](https://vibekit.bot) - An AI coding agent that builds, hosts, and keeps improving full apps (live URL and optional database included), driven from a phone or CLI. The free tier includes building on a rotating pool of free models at no cost, plus bring-your-own Claude or OpenAI key at zero markup.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adding **VibeKit.bot** to the **Code Generation** section — it fits alongside Appinvento, Karbon Sites, and v0.dev (AI-driven app/code generation with a genuine free tier).

**What it is:** an AI coding agent that builds, hosts, and keeps improving full apps (live URL + optional database), driven from a phone (native iOS) or CLI.

**Free tier (per the list's rules — a free tier, not a trial):** you can build on a rotating pool of free models at $0 indefinitely (not time-bucketed), plus bring-your-own Claude/OpenAI key at zero markup. As-a-Service (not self-hosted); apps are served over HTTPS on all tiers.

Alphabetized within the section (after v0.dev). Listed as **VibeKit.bot** to disambiguate from the unrelated `superagent-ai/vibekit` SDK. Maker-submitted.