### PR TITLE
Add DietlyAPI to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [DeepAR](https://developer.deepar.ai) - Augmented reality face filters for any platform with one SDK. The free plan provides up to 10 monthly active users (MAU) and tracks up to 4 faces
   * [Deepnote](https://deepnote.com) - A new data science notebook. Jupyter is compatible with real-time collaboration and running in the cloud. The free tier includes unlimited personal projects, unlimited basic machines with 5GB RAM and 2vCPU, and teams with up to 3 editors.
   * [Compare JSON](https://comparejson.com) - An online tool for comparing differences between two JSON data structures, helping you quickly locate the differences in JSON data.
+  * [DietlyAPI](https://www.getdietly.com/api.html) - Food & nutrition API, 4.2M+ foods with macros, micronutrients and barcode lookup. Free tier: instant key, no card, 30 requests per minute (non-commercial).
   * [Disease.sh](https://disease.sh/) - A free API providing accurate data for building the Covid-19 related useful Apps.
   * [Doczilla](https://www.doczilla.app/) - SaaS API empowering the generation of screenshots or PDFs directly from HTML/CSS/JS code. The free plan allows 250 documents month.
   * [Doppio](https://doppio.sh/) - Managed API to generate and privately store PDFs and Screenshots using top rendering technology. The free plan allows 400 PDFs and Screenshots per month.


### PR DESCRIPTION
Adds [DietlyAPI](https://www.getdietly.com/api) under **APIs, Data, and ML** (alphabetical position).

DietlyAPI is a food & nutrition API with 4.2M+ foods (macros, micronutrients, barcode lookup). The free tier is genuinely free for developers: instant self-serve API key, no credit card, 30 requests/minute, full database access (non-commercial use).
