### PR TITLE
Add What Is My Tools to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1641,6 +1641,7 @@ Update Time, five active automations, webhooks.
   * [SYNCDATE](https://syncdate.app) - Two-way Google Calendar sync. Free tier: 2 accounts, unlimited events.
   * [UUID Generator](https://newuuid.com/) - Generate UUID v1, UUID v4, UUID v7, GUID, Nil UUIDs, CUID v1/v2, NanoID, and ULID instantly with enterprise-grade
   * [Versionfeeds](https://versionfeeds.com) - Custom RSS feeds for releases of your favorite software. Have the latest versions of your programming languages, libraries, or loved tools in one feed. (The first 3 feeds are free)
+  * [What Is My Tools](https://whatismytools.com) - Free browser-based network and diagnostic tools: check your public IP and ISP, run a speed test, detect WebRTC/DNS/VPN leaks, inspect your browser fingerprint and user agent, view WebGL/GPU info, and check open ports, timezone, and geolocation. No signup, instant results.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adds **What Is My Tools** (https://whatismytools.com) to the Miscellaneous section.

It's a free, browser-based suite of network/diagnostic tools — public IP & ISP, speed test, WebRTC/DNS/VPN leak detection, browser fingerprint & user agent, WebGL/GPU info, open ports, timezone and geolocation. Everything runs client-side with instant results.

**Eligibility:** entirely free, no signup, not a time-limited trial. Fits alongside existing entries like Hosting Checker, and What Is My IP / Multi-Exit IP Address Checker in the APIs section.

**Disclosure:** I'm affiliated with the site (maintainer). Happy to adjust the wording or move it to a better-fitting section.

- [x] Free tier (not a trial)
- [x] Alphabetical placement within the section
- [x] Single entry, one line