### PR TITLE
Update Rivestack free tier description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,7 +1202,7 @@ Update Time, five active automations, webhooks.
   * [Prisma Postgres](https://prisma.io/postgres) - Super fast hosted Postgres built on unikernels and running on bare metal, 500MB total storage, 5 databases, integrated with Prisma ORM.
   * [Qdrant](https://qdrant.tech/) - Vector Database for embedding data, single node cluster with 0.5 vCPU, 1GB RAM, and 4GB disk.
   * [restdb.io](https://restdb.io/) - a fast and straightforward NoSQL cloud database service. With restdb.io you get schema, relations, automatic REST API (with MongoDB-like queries), and an efficient multi-user admin UI for working with data. The free plan allows 3 users, 2500 records, and 1 API request per second.
-  * [Rivestack](https://rivestack.io) - Managed PostgreSQL with pgvector optimized for AI workloads. The free tier includes 2GB storage, daily snapshots, 14-day point-in-time recovery, and a built-in SQL editor that converts search queries to vector embeddings.
+  * [Rivestack](https://rivestack.io) - Managed PostgreSQL with pgvector pre-installed, optimized for AI and semantic search. Free tier includes one database with 2 GB storage, never paused, and a built-in SQL editor that converts search queries to vector embeddings.
   * [SeaTable](https://seatable.io/) - Flexible, Spreadsheet-like Database built by the Seafile team. unlimited tables, 2,000 lines, 1-month versioning, up to 25 team members.
   * [skyvia.com](https://skyvia.com/) - Cloud Data Platform offers a free tier and all plans are completely free while in beta
   * [StackBy](https://stackby.com/) - One tool that combines spreadsheets' flexibility, databases' power, and built-in integrations with your favorite business apps. The free plan includes unlimited users, ten stacks, and a 2GB attachment per stack.


### PR DESCRIPTION
I'm the founder of Rivestack. Our current entry says the free tier includes daily snapshots and 14 day point in time recovery, but the free tier does not include backups. This updates the description to what the free tier actually offers, so readers are not promised a restore feature that is not there. One line changed, no other entries touched.