### PR TITLE
Add Apstal - AI-first web analytics with session replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1480,6 +1480,7 @@ Update Time, five active automations, webhooks.
   * [amplitude.com](https://amplitude.com/) - 1 million monthly events, up to 2 apps
   * [AppFit](https://appfit.io) - AppFit is a comprehensive analytics and product management tool designed to facilitate seamless, cross-platform management of analytics and product updates. Free plan includes 10,000 events per month, product journal and weekly insights.
   * [Aptabase](https://aptabase.com) - Open Source, Privacy-Friendly, and Simple Analytics for Mobile and Desktop Apps. SDKs for Swift, Kotlin, React Native, Flutter, Electron, and many others. Free for up to 20,000 events per month.
+  * [Apstal](https://apstal.com) - AI-first web analytics with session replay, heatmaps, and conversational AI queries. Free tier available (3K events/month).
   * [Avo](https://avo.app/) - Simplified analytics release workflow. Single-source-of-truth tracking plan, type-safe analytics tracking library, in-app debuggers, and data observability to catch all data issues before you release. Free for two workspace members and 1 hour data observability lookback.
   * [Beampipe.io](https://beampipe.io) - Beampipe is simple, privacy-focussed web analytics. free for up to 5 domains & 10k monthly page views.
   * [Census](https://www.getcensus.com/) - Reverse ETL & Operational Analytics Platform. Sync 10 fields from your data warehouse to 60+ SaaS like Salesforce, Zendesk, or Amplitude.


### PR DESCRIPTION
Adds [Apstal](https://apstal.com) to the Analytics section.

**Apstal** is an AI-first web analytics platform with session replay, heatmaps, and conversational AI queries. The free tier handles up to 30,000 monthly events.

- AI-powered analytics queries via natural language
- Session replay with rrweb
- Heatmaps and click tracking
- Adblock-resistant tracking (WebSocket priority + HTTP fallback)
- Free tier: 30,000 events/month