### PR TITLE
Add HTML to PDF API (free tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Hook0](https://www.hook0.com/) - Hook0 is an open-source Webhooks-as-a-service (WaaS) that makes it easy for online products to provide webhooks. Dispatch up to 100 events/day with seven days of history retention for free.
   * [Hoppscotch](https://hoppscotch.io) - A free, fast, and beautiful API request builder.
   * [HS Ping](https://hsping.com) - A multi-country HS (Harmonized System) and HTS (Harmonized Tariff System) code lookup API, with a free plan offering 100 lookups/day.
+  * [HTML to PDF API](https://app.htmlpdfapi.workers.dev/go/ffd) - Convert HTML into production PDFs (invoices, reports, contracts) with one POST; hosted headless Chrome, nothing stored. Free tier: 300 PDFs/month, no card.
   * [huggingface.co](https://huggingface.co) - Build, train, and deploy NLP models for Pytorch, TensorFlow, and JAX. Free up to 30k input characters/mo.
   * [Insomnia](https://insomnia.rest) - Open-source API client for designing and testing APIs, it supports REST and GraphQL
   * [Inngest](https://www.inngest.com) - Durable execution and event-driven workflows for TypeScript, Python, and Go. Hobby plan is free with 50k executions/month, 5 concurrent steps, 500k events ingested, and no credit card required.


### PR DESCRIPTION
Adds a hosted HTML-to-PDF API with a free tier (300 PDFs/month, no card). One POST, PDF back; nothing stored. Disclosure: I maintain it.