### PR TITLE
Add DevKits to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [DB-IP](https://db-ip.com/api/free) - Free IP geolocation API with 1k request per IP per day.lite database under the CC-BY 4.0 License is free too.
   * [DeepAR](https://developer.deepar.ai) - Augmented reality face filters for any platform with one SDK. The free plan provides up to 10 monthly active users (MAU) and tracks up to 4 faces
   * [Deepnote](https://deepnote.com) - A new data science notebook. Jupyter is compatible with real-time collaboration and running in the cloud. The free tier includes unlimited personal projects, unlimited basic machines with 5GB RAM and 2vCPU, and teams with up to 3 editors.
+  * [DevKits](https://devkits.vip) - Collection of 160+ browser-based developer utilities (JSON/YAML/XML/CSV conversion, JWT/JWS/JWKS, RSA/ECDSA key generation, PDF and image tools, regex, CSS visualizers, AI cost estimator). Runs 100% client-side via the Web Crypto API — nothing uploaded, no account, no premium tier, free forever.
   * [Compare JSON](https://comparejson.com) - An online tool for comparing differences between two JSON data structures, helping you quickly locate the differences in JSON data.
   * [Disease.sh](https://disease.sh/) - A free API providing accurate data for building the Covid-19 related useful Apps.
   * [Doczilla](https://www.doczilla.app/) - SaaS API empowering the generation of screenshots or PDFs directly from HTML/CSS/JS code. The free plan allows 250 documents month.


### PR DESCRIPTION
Adding DevKits to the `APIs, Data, and ML` section.

**What it is**: A collection of 160+ browser-based developer utilities: JSON/YAML/XML/CSV conversion, JWT & JWS handling, RSA/ECDSA key generation and sign/verify, PDF & image tools, regex tester and cookbook, CSS layout visualizers, AI cost estimator, plus reference tables for HTTP status codes, MIME types, and ASCII.

**Compliance with the list's rules** (from README):
- ✅ SaaS/web offering, not self-hosted software
- ✅ Permanent free tier — no paid plan exists, will remain free forever
- ✅ HTTPS/TLS, no TLS restrictions on any features
- ✅ Not time-bucketed / not a trial

**Section fit**: The section already contains similar in-browser JSON/data utilities (Compare JSON, JSONing, JSONSwiss, FormatJSONOnline.com, JSONGrid, drawDB), setting a precedent for online developer-facing tools alongside API services.

Followed the existing `* [Name](url) - Description.` format. No duplicate — searched the file.
