### PR TITLE
Add AlterLab free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 
   * [Abstract API](https://www.abstractapi.com) - API suite for various use cases, including IP geolocation, phone number validation, or email validation.
   * [AlphaAI](https://alphai.io/developers) - Financial news API and MCP server. Every article gets per-ticker impact analysis, a category, and a 1-10 relevance score, and SEC Form 4 insider filings are turned into scored events. The free tier includes 20 requests per minute and 100 requests per day on both REST and MCP, no card required.
-  * [AlterLab](https://alterlab.io) - Web data API for scrape, crawl, search, map, and extract with automatic anti-bot bypass and JavaScript rendering. Free tier includes $1 in credits on signup, no subscription required, no expiry.
+  * [AlterLab](https://alterlab.io) - Web data API for scrape, crawl, search, map, and extract with automatic website compatibility and JavaScript rendering. Free tier includes $1 in credits on signup, no subscription required, no expiry.
   * [Apify](https://www.apify.com/) - Web scraping and automation platform to create an API for any website and extract data. Ready-made scrapers, integrated proxies, and custom solutions. Free plan with $5 platform credits included every month.
   * [APITemplate.io](https://apitemplate.io) - Auto-generate images and PDF documents with a simple API or automation tools like Zapier & Airtable. No CSS/HTML is required. The free plan comes with 50 images/month and three templates.
   * [APIVerve](https://apiverve.com) - Get instant access to over 120+ APIs for free, built with quality, consistency, and reliability in mind. The free plan covers up to 50 API Tokens per month. (Possibly taken down, 2025-06-25)

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 
   * [Abstract API](https://www.abstractapi.com) - API suite for various use cases, including IP geolocation, phone number validation, or email validation.
   * [AlphaAI](https://alphai.io/developers) - Financial news API and MCP server. Every article gets per-ticker impact analysis, a category, and a 1-10 relevance score, and SEC Form 4 insider filings are turned into scored events. The free tier includes 20 requests per minute and 100 requests per day on both REST and MCP, no card required.
+  * [AlterLab](https://alterlab.io) - Web data API for scrape, crawl, search, map, and extract with automatic anti-bot bypass and JavaScript rendering. Free tier includes $1 in credits on signup, no subscription required, no expiry.
   * [Apify](https://www.apify.com/) - Web scraping and automation platform to create an API for any website and extract data. Ready-made scrapers, integrated proxies, and custom solutions. Free plan with $5 platform credits included every month.
   * [APITemplate.io](https://apitemplate.io) - Auto-generate images and PDF documents with a simple API or automation tools like Zapier & Airtable. No CSS/HTML is required. The free plan comes with 50 images/month and three templates.
   * [APIVerve](https://apiverve.com) - Get instant access to over 120+ APIs for free, built with quality, consistency, and reliability in mind. The free plan covers up to 50 API Tokens per month. (Possibly taken down, 2025-06-25)


### PR DESCRIPTION
Adds AlterLab to the web scraping / data APIs section.

[AlterLab](https://alterlab.io) is a web data API covering scrape, crawl, search, map, and extract, with automatic website compatibility and JavaScript rendering.

**Free tier:** $1 in credits on signup — no subscription, no card required, and the credits do not expire. That is roughly 5,000 requests on the standard tier.

Entry follows the existing format and is placed alphabetically in the section.
