### PR TITLE
Add DataCube AI to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [CustomJS](https://www.customjs.io) - HTML to PDF or PDF to PNG/Text & PDF merging/extraction/merging APIs. Free tier has 600 calls a month.
   * [Data Fetcher](https://datafetcher.com) - Connect Airtable to any application or API with no code. Postman-like interface for running API requests in Airtable. Pre-built integrations with dozens of apps. The free plan includes 100 runs per month.
   * [Data Miner](https://dataminer.io/) - A browser extension (Google Chrome, MS Edge) for data extraction from web pages CSV or Excel. The free plan gives you 500 pages/month.
+  * [DataCube AI](https://www.datacubeai.space/en/tools/ai-news-api) - Daily curated AI industry news, funding/M&A deals and trend topics as JSON in 8 languages. Public endpoints are free with no API key; free developer keys available for higher limits.
   * [Dataimporter.io](https://www.dataimporter.io) - Tool for connecting, cleaning, and importing data into Salesforce. Free Plan includes up to 20,000 records per month.
   * [Datalore](https://datalore.jetbrains.com) - Python notebooks by Jetbrains. Includes 10 GB of storage and 120 hours of runtime each month.
   * [DB Designer](https://www.dbdesigner.net/) - Cloud-based Database schema design and modeling tool with a free starter plan of 2 Database models and ten tables per model.


### PR DESCRIPTION
Adds [DataCube AI](https://www.datacubeai.space/en/tools/ai-news-api) to the APIs, Data, and ML section (alphabetical position).

Free tier summary: all public JSON endpoints (daily AI news, funding/M&A, trend topics in 8 languages) are free with no API key and no card; free developer keys available for higher rate limits. The free tier is permanent, not a trial.