### PR TITLE
Add Apstal to Analytics, Events and Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1472,6 +1472,7 @@ Update Time, five active automations, webhooks.
 
 ## Analytics, Events and Statistics
 
+  * [Apstal](https://apstal.com) - Cookieless web analytics with session replay, heatmaps, funnels, error tracking, and an AI assistant that answers questions about your data in plain language. Free tier: 100,000 events/month including session replays and heatmaps, no credit card required.
   * [amplitude.com](https://amplitude.com/) - 1 million monthly events, up to 2 apps
   * [AppFit](https://appfit.io) - AppFit is a comprehensive analytics and product management tool designed to facilitate seamless, cross-platform management of analytics and product updates. Free plan includes 10,000 events per month, product journal and weekly insights.
   * [Aptabase](https://aptabase.com) - Open Source, Privacy-Friendly, and Simple Analytics for Mobile and Desktop Apps. SDKs for Swift, Kotlin, React Native, Flutter, Electron, and many others. Free for up to 20,000 events per month.


### PR DESCRIPTION
Adds [Apstal](https://apstal.com) to the **Analytics, Events and Statistics** section.

## What is Apstal?

Apstal is a privacy-first web analytics platform built for developers and product teams who want accurate data without the complexity of Google Analytics or the privacy concerns of cookie-based tracking.

## Key features

- **Cookieless tracking**: No HTTP cookies, no consent banners, no GDPR/ePrivacy complications. Data is anonymized at collection time on the server side.
- **Adblock-resistant**: The tracker script does not load from known analytics domains and does not match EasyList/EasyPrivacy heuristic rules. Sessions from visitors with uBlock Origin, Brave, or AdGuard are fully captured. In production, 8.6% of sessions arrive with an active adblocker and would be invisible to cookie-based tools.
- **Session replay**: Record and replay visitor sessions to see exactly how users interact with your site. Useful for debugging UX issues, understanding drop-offs, and reproducing bugs.
- **Heatmaps**: Visual click and scroll-depth overlays on top of your pages.
- **Conversion funnels**: Build multi-step funnels and compare conversion rates across traffic sources.
- **Error tracking**: JavaScript errors, console errors, broken assets, and network failures are captured automatically.
- **AI assistant**: Ask questions about your data in plain English (e.g., "What was my top traffic source last week?" or "Show the funnel for the checkout page") and get instant answers with charts.
- **Real-time dashboard**: Live visitor count, active sessions, and event stream with WebSocket updates.

## Free tier

- **100,000 events per month** (includes pageviews, clicks, custom events)
- Session replays and heatmaps included
- No credit card required
- Unlimited team members
- Data retention: 30 days

This qualifies as a genuine free tier (not a trial) - it does not expire and does not require payment information.

## Placement

Added alphabetically at the top of the Analytics, Events and Statistics section, before Amplitude, matching the existing list format (single line, dash-separated description, free tier details).