### PR TITLE
Add OrbitalWiki to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [numlookupapi.com](https://numlookupapi.com) - Free phone number validation API - 100 free requests / month.
   * [OCR.Space](https://ocr.space/) - An OCR API parses image and pdf files that return the text results in JSON format. 25,000 requests per month are free and a 1MB file size limit.
   * [OpenAPI3 Designer](https://openapidesigner.com/) - Visually create Open API 3 definitions for free.
+  * [OrbitalWiki](https://www.orbitalwiki.com/developers) - Read-only REST API over a catalogue of 16,000+ objects in Earth orbit: orbital elements, operators, NORAD/COSPAR IDs, launch history. Every field names the source it came from and returns unknown rather than guessing. Free tier is 1,000 requests/day with no key and no card; a key raises the limit.
   * [Parseur](https://parseur.com) - 20 free pages/month: Extract data from PDFs, emails. AI powered. Full API access.
   * [PDF-API.io](https://pdf-api.io) - PDF Automation API, visual template editor or HTML to PDF, dynamic data integration, and PDF rendering with an API. The free plan comes with one template, 100 PDFs/month.
   * [PDFBolt](https://pdfbolt.com) - Developer-focused PDF generation API designed with privacy in mind. It offers Stripe-inspired documentation and includes 500 free PDF conversions per month.


### PR DESCRIPTION
Adds OrbitalWiki, a read-only REST API over a public catalogue of objects in Earth orbit.

**Entry**

```
* [OrbitalWiki](https://www.orbitalwiki.com/developers) - Read-only REST API over a catalogue of 16,000+ objects in Earth orbit: orbital elements, operators, NORAD/COSPAR IDs, launch history. Every field names the source it came from and returns unknown rather than guessing. Free tier is 1,000 requests/day with no key and no card; a key raises the limit.
```

**Free tier, stated precisely**

1,000 requests per day. No credit card, and no key at all for the public endpoints:

```
$ curl -s -o /dev/null -w '%{http_code}' 'https://www.orbitalwiki.com/api/v1/satellites?limit=1'
200
```

A free account raises the limit; paid tiers exist above that but nothing in the free tier expires or requires a card.

**Why it is worth a line here**

Other public satellite APIs give you a number. This one merges CelesTrak orbital elements, Jonathan McDowell's GCAT launch catalogue, Wikidata metadata and SatNOGS radio records into one record per object and tells you, per field, which of those it came from. Where the sources disagree or say nothing it returns `unknown` instead of filling the gap, so you can tell a real gap from a guess. Responses carry `X-OrbitalWiki-Sources` and `X-OrbitalWiki-License` headers, and CORS is open, so it works straight from a browser.

Alphabetical position kept: inserted between OpenAPI3 Designer and Parseur.