### PR TITLE
Add Domainee to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [pubnub.com](https://www.pubnub.com/) - Free push notifications for up to 1 million messages/month and 100 active daily devices
   * [pusher.com](https://pusher.com/beams) - Free, unlimited push notifications for 2000 monthly active users. A single API for iOS and Android devices.
   * [simperium.com](https://simperium.com/) - Move data everywhere instantly and automatically, multi-platform, unlimited sending and storage of structured data, max. 2,500 users/month
+  * [Simceptor](https://simceptor.com/) - No-code mock API server for developers to create and test REST, SOAP, and WSDL APIs with conditional rules, dynamic data, latency simulation, and webhooks. Free forever with 3 projects, 10 mocks per project, and 10 rules per mock.
   * [snill.ai](https://snill.ai) - AI no-code platform that turns a plain-language description into a complete business system with a relational database, dashboards, workflows, REST API and webhooks. Free plan for solo operators includes 2 apps, 1,000 records and 10 AI requests/day.
   * [Supabase](https://supabase.com) - The Open Source Firebase Alternative to build backends. Free Plan offers Authentication, Realtime Database & Object Storage.
   * [tyk.io](https://tyk.io/) - API management with authentication, quotas, monitoring and analytics. Free cloud offering

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Doppio](https://doppio.sh/) - Managed API to generate and privately store PDFs and Screenshots using top rendering technology. The free plan allows 400 PDFs and Screenshots per month.
   * [DocPenny](https://docpenny.com) - HTML to PDF document generation with templates, webhook delivery, and credit-based pricing. Free plan with 50 monthly credits, no credit card required.
   * [Doqlo](https://doqlo.com/) - Bulk fill and mail merge PDF forms from CSV using the web app or Public API. The free plan includes 100 output PDFs/month.
+  *[Domainee](https://domainee.dev/) - Custom domains API for SaaS applications with automatic SSL issuance, renewal, DNS monitoring, and webhooks. Free for 50 customer domains and 100 GB bandwidth per month.
   * [drawDB](https://drawdb.app/) - Free and open-source online database diagram editor with no signup required.
   * [DynamicDocs](https://advicement.io) - Generate PDF documents with JSON to PDF API based on LaTeX templates. The free plan allows 50 API calls per month and access to a library of templates.
   * [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API. Free tier includes 15 requests per minute.


### PR DESCRIPTION
Added Domainee to the APIs, Data and ML section.

Domainee provides a custom domains API for SaaS applications, including SSL management, DNS monitoring and webhooks.

The free tier includes 50 customer domains and 100 GB bandwidth per month.