### PR TITLE
Add finlight to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Export SDK](https://exportsdk.com) - PDF generator API with drag-and-drop template editor that provides an SDK and no-code integrations. The free plan has 250 monthly pages, unlimited users, and three templates.
   * [ExtendsClass](https://extendsclass.com/rest-client-online.html) - Free web-based HTTP client to send HTTP requests.
   * [Financial Data](https://financialdata.net/) - Stock market and financial data API. Free plan allows 300 requests per day.
+  * [finlight](https://finlight.me) - Real-time financial news API with entity resolution (tickers, ISIN) and sentiment tagging, available over REST, WebSocket, webhooks and an MCP server. Free tier: 5,000 requests/month on both REST and MCP, 12-hour delayed articles, no card required.
   * [Firecrawl](https://www.firecrawl.dev/) - API that crawls websites and converts them into clean, LLM-ready markdown or structured data, handling JavaScript rendering, proxies, and rate limits. The free plan includes 1,000 credits per month with no credit card required.
   * [FormatJSONOnline.com](https://formatjsononline.com) - A free, browser-based tool to format, validate,compare and minify JSON data instantly.
   * [FraudLabs Pro](https://www.fraudlabspro.com) - Screen an order transaction for credit card payment fraud. This REST API will detect all possible fraud traits based on the input parameters of an order. The Free Micro plan has 500 transactions per month.


### PR DESCRIPTION
Adds finlight, a financial news API, to the APIs, Data, and ML section.

* SaaS, not self-hosted
* Permanent free tier, not a trial: 5,000 requests/month with 12-hour delayed articles
* Pricing is public at https://finlight.me/pricing, no signup or sales call needed
* What is free: REST and MCP access to headlines, summaries, sentiment field, source and link, with articles delayed by 12 hours. WebSocket streaming, webhooks and undelayed delivery are on paid tiers.
* Not currently listed
* Operator contact at info@finlight.me, imprint at https://finlight.me/imprint, privacy policy at https://finlight.me/privacy-policy