### PR TITLE
Add rasterly to Screenshot APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1613,6 +1613,7 @@ Update Time, five active automations, webhooks.
   * [ApiFlash](https://apiflash.com) - A screenshot API based on Aws Lambda and Chrome. Handles full page, captures timing, and viewport dimensions.
   * [microlink.io](https://microlink.io/) - It turns any website into data such as metatags normalization, beauty link previews, scraping capabilities, or screenshots as a service. 50 requests/day every day free.
   * [PhantomJsCloud](https://PhantomJsCloud.com) - Browser automation and page rendering.  Free Tier offers up to 500 pages/day.  Free Tier since 2017.
+  * [rasterly](https://rasterly.dev) - Screenshot & PDF API. Any URL to PNG, JPEG or PDF over one HTTP call, full-page and retina. Free plan includes 100 renders/month.
   * [screenshotbase.com](https://screenshotbase.com) - 300 free screenshots / month. Take screenshots from any url. Fast, free & scalable.
   * [screenshotlayer.com](https://screenshotlayer.com/) - Capture highly customizable snapshots of any website. Free 100 snapshots/month
   * [screenshotmachine.com](https://www.screenshotmachine.com/) - Capture 100 snapshots/month, png, gif and jpg, including full-length captures, not only home page


### PR DESCRIPTION
Adds **rasterly** to the Screenshot APIs section (placed alphabetically).

rasterly is a screenshot & PDF API — any URL to PNG, JPEG or PDF over one HTTP call, full-page and retina. Free plan: 100 renders/month, no card required. Live demo, no signup: https://rasterly.dev

Checklist:
- [x] Free tier (100 renders/month)
- [x] Alphabetical order
- [x] One line, matches format