### PR TITLE
Add The Gold Barometer to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Svix](https://www.svix.com/) - Webhooks as a Service. Send up to 50,000 messages/month for free.
   * [Tavily AI](https://tavily.com/) - API for online search and rapid insights and comprehensive research, with the capability of organization of research results. 1000 request/month for the Free tier with No credit card required.
   * [TemplateFox](https://pdftemplateapi.com) - PDF generation API with a visual template editor, dynamic data merging, and SDKs for 7 languages. Free plan includes 60 PDFs/month and 3 templates.
+  * [The Gold Barometer](https://thegoldbarometer.com/data/) - Daily gold buying-conditions score (0-100) as a free JSON API and open dataset, history back to 1971. Completely free, no auth and no key, data CC BY 4.0.
   * [The IP API](https://theipapi.com/) - IP Geolocation API with 1000 free requests / day. Provides information about the location of an IP address, including country, city, region, and more.
   * [TinyMCE](https://www.tiny.cloud) - rich text editing API. Core features are free for unlimited usage.
   * [Tomorrow.io Weather API](https://www.tomorrow.io/weather-api/) - Offers free plan of weather API. Provides accurate and up-to-date weather forecasting with global coverage, historical data and weather monitoring solutions.


### PR DESCRIPTION
Adds The Gold Barometer: a daily gold buying-conditions score (0-100) served as a free JSON API (no auth, no key, CORS enabled) with an open CC BY 4.0 dataset back to 1971, archived daily on GitHub.

The free tier is the whole product: there is no paid tier, no signup and no request cap. Alphabetical placement: before The IP API.