### PR TITLE
Add PennyOCR (OCR API — 100 free pages/month)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [OCR.Space](https://ocr.space/) - An OCR API parses image and pdf files that return the text results in JSON format. 25,000 requests per month are free and a 1MB file size limit.
   * [OpenAPI3 Designer](https://openapidesigner.com/) - Visually create Open API 3 definitions for free.
   * [Parseur](https://parseur.com) - 20 free pages/month: Extract data from PDFs, emails. AI powered. Full API access.
+  * [PennyOCR](https://pennyocr.com) - OCR API that turns PDFs and images into markdown or plain text (tables preserved). Free tier: 100 pages/month, no credit card required.
   * [PDF-API.io](https://pdf-api.io) - PDF Automation API, visual template editor or HTML to PDF, dynamic data integration, and PDF rendering with an API. The free plan comes with one template, 100 PDFs/month.
   * [PDFBolt](https://pdfbolt.com) - Developer-focused PDF generation API designed with privacy in mind. It offers Stripe-inspired documentation and includes 500 free PDF conversions per month.
   * [Pexafy](https://pexafy.com) - Semantic image search API across 9 free photo sources (Unsplash, Pexels, Pixabay, Kaboompics & more), 9M+ photos under one JSON schema instead of one integration per source. Plain-language queries, reverse image search, filters on color, orientation and license. CORS is open on read endpoints, so it runs from the browser. The free plan includes 5,000 API requests/month and 1 key, no app review.


### PR DESCRIPTION
Adds [PennyOCR](https://pennyocr.com) to the APIs, Data, and ML section (alphabetical, after Parseur).

PennyOCR is an OCR API that converts PDFs and images to markdown (tables preserved) or plain text. The free tier is 100 pages per month, forever, with no credit card required — docs at https://pennyocr.com/docs/ and a plain-text summary at https://pennyocr.com/pricing.txt.

Disclosure: I'm the maintainer of PennyOCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)