### PR TITLE
Add SwiftNodes (blockchain RPC API, permanent free tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Zipcodestack](https://zipcodestack.com) - Free Zip Code API and Postal Code Validation. Ten thousand free requests/month.
   * [Zuplo](https://zuplo.com/) - Free API Management platform to design, build, and deploy APIs to the Edge. Add API Key authentication, rate limiting, developer documentation and Monetization to any API in minutes. OpenAPI-native and fully-programmable with web standard apis & Typescript. The free plan offers up to 10 projects, unlimited production edge environments, 1M monthly requests, and 10GB egress.
   * [Metashot](https://metashot.io) — Open Graph (OG) social preview image generation API. Generate dynamic 1200×630 images for Twitter, LinkedIn and Facebook via URL params, edge-cached on Cloudflare Workers. Free tier: 1,000 renders/month. Paid plans from $12/month.
+  * [SwiftNodes](https://swiftnodes.io/) - Blockchain RPC API for Ethereum, Solana and 75+ networks. Free tier includes 250,000 requests/month over HTTP and WebSocket, no credit card required.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adds SwiftNodes: blockchain RPC endpoints for Ethereum, Solana and 75+ networks. The free tier is permanent (not a trial): 250,000 requests/month, HTTP + WebSocket, no credit card or KYC required.