### PR TITLE
Add SMTPfast to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Sendpulse](https://sendpulse.com) - 500 subscribers/month, 15,000 emails/month free
   * [SendStreak](https://www.sendstreak.com/) - Email framework as a service, that adds templates, automations, history, etc to your own SMTP server (E.g. AWS, Maileroo, Gmail). Free up to 100 emails/day, no time limit.
   * [SimpleLogin](https://simplelogin.io/) - Open source, self-hostable email alias/forwarding solution. Free 10 Aliases, unlimited bandwidth, unlimited reply/send. Free for educational staff (student, researcher, etc.).
+  * [SMTPfast](https://smtpfa.st) - Transactional email API and SMTP relay. Free 3,000 emails/month, 1 domain, 1,000 contacts, REST API and hosted MCP server.
   * [Substack](https://substack.com) - Unlimited free newsletter service. Start paying when you charge for it.
   * [Suped](https://www.suped.com/) - A user-friendly DMARC monitoring platform. The free plan covers one domain with up to 1,000 emails per month.
   * [Sweego](https://www.sweego.io/) - European transactional emails API for developers. 100 emails/day free.


### PR DESCRIPTION
Adds SMTPfast to the Email section. Free tier: 3,000 emails/month, 1 verified domain, 1,000 contacts, REST API (Resend-compatible), SMTP relay and a hosted MCP server. No credit card required.

Disclosure: I work on this product.
