### PR TITLE
Add PairBook to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [numlookupapi.com](https://numlookupapi.com) - Free phone number validation API - 100 free requests / month.
   * [OCR.Space](https://ocr.space/) - An OCR API parses image and pdf files that return the text results in JSON format. 25,000 requests per month are free and a 1MB file size limit.
   * [OpenAPI3 Designer](https://openapidesigner.com/) - Visually create Open API 3 definitions for free.
+  * [PairBook](https://www.pairbook.io/api/) - Correlation, covariance, beta, volatility and ETF holdings overlap for 4,700+ US stocks and ETFs, recomputed every trading day. Free JSON API with no key or signup, CORS enabled, OpenAPI 3.1 spec.
   * [Parseur](https://parseur.com) - 20 free pages/month: Extract data from PDFs, emails. AI powered. Full API access.
   * [PDF-API.io](https://pdf-api.io) - PDF Automation API, visual template editor or HTML to PDF, dynamic data integration, and PDF rendering with an API. The free plan comes with one template, 100 PDFs/month.
   * [PDFBolt](https://pdfbolt.com) - Developer-focused PDF generation API designed with privacy in mind. It offers Stripe-inspired documentation and includes 500 free PDF conversions per month.


### PR DESCRIPTION
Adds PairBook: correlation, covariance, beta, volatility and ETF holdings overlap for 4,700+ US-listed stocks and ETFs, recomputed every trading day from public data. The JSON API is free with no key, signup or card: CORS enabled, OpenAPI 3.1 spec at https://www.pairbook.io/api/openapi.json, docs at https://www.pairbook.io/api/. Entry placed alphabetically in APIs, Data, and ML.