### PR TITLE
Add DevScratchpad under IDE and Code Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1473,7 +1473,8 @@ Update Time, five active automations, webhooks.
   * [Code::Blocks](https://codeblocks.org) - Free Fortran & C/C++ IDE. Open Source and runs on Windows,macOS & Linux.
   * [Codeground](https://codeground.ai/) - Free browser IDE and playgrounds for 15+ languages plus Postgres, MySQL, MongoDB, and Redis. Shareable snippets, coding interviews, and cloud workspaces. Free playgrounds need no install.
   * [codiga.io](https://codiga.io/) - Coding Assistant that lets you search, define, and reuse code snippets directly in your IDE. Free for individual and small organizations.
-  * [Components.studio](https://webcomponents.dev/) - Code components in isolation, visualize them in stories, test them, and publish them on npm.
+  * [components.studio](https://webcomponents.dev/) - Code components in isolation, visualize them in stories, test them, and publish them on npm.
+  * [DevScratchpad](https://tools.saadengineer.works) - An open-source, privacy-first developer utility suite (19+ tools) with Monaco editor, real-time syntax checking, and zero server transmission. Deployable in 1-click.
   * [Eclipse Che](https://www.eclipse.org/che/) - Web-based and Kubernetes-Native IDE for Developer Teams with multi-language support. Open Source and community-driven. An online instance hosted by Red Hat is available at [workspaces.openshift.com](https://workspaces.openshift.com/).
   * [ForgeCode](https://forgecode.dev/) - AI-enabled pair programmer for Claude, GPT4 Series, Grok, Deepseek, Gemini and all frontier models. Works natively with your CLI and integrates seamlessly with any IDE. Free tier includes basic AI model access with local processing.
   * [GetVM](https://getvm.io) - Instant free Linux and IDEs chrome sidebar. The free tier includes 5 VMs per day.


### PR DESCRIPTION
Adding **DevScratchpad**, an open-source, privacy-focused developer utility workspace (19+ tools) with Monaco editor and real-time syntax checking.

### Why this is different from generic 'toolbox' sites:
- **No server-side processing:** All operations execute in the client's local browser memory.
- **Self-Hostable Boilerplate:** Designed as a free React/Next.js package that developers and DevOps teams can deploy in 1-click on their own VPC/servers to satisfy security policies.
- **Developer-centric UX:** Focuses on clean workspaces using VS Code's editor engine, status bars, and shortcut navigation rather than ad-bloated textboxes.

- **URL:** https://tools.saadengineer.works
- **License:** MIT
- **Pricing:** 100% Free and open source.