### PR TITLE
Add ParlayAPI to APIs, Data, and ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [numlookupapi.com](https://numlookupapi.com) - Free phone number validation API - 100 free requests / month.
   * [OCR.Space](https://ocr.space/) - An OCR API parses image and pdf files that return the text results in JSON format. 25,000 requests per month are free and a 1MB file size limit.
   * [OpenAPI3 Designer](https://openapidesigner.com/) - Visually create Open API 3 definitions for free.
+  * [ParlayAPI](https://parlay-api.com) - Sports odds and player props API covering 30+ sportsbooks plus Kalshi and Polymarket prediction markets, with the-odds-api compatible endpoints and historical odds. The free tier includes 1,000 credits per month, no credit card required.
   * [Parseur](https://parseur.com) - 20 free pages/month: Extract data from PDFs, emails. AI powered. Full API access.
   * [PDF-API.io](https://pdf-api.io) - PDF Automation API, visual template editor or HTML to PDF, dynamic data integration, and PDF rendering with an API. The free plan comes with one template, 100 PDFs/month.
   * [PDFBolt](https://pdfbolt.com) - Developer-focused PDF generation API designed with privacy in mind. It offers Stripe-inspired documentation and includes 500 free PDF conversions per month.


### PR DESCRIPTION
Adds ParlayAPI, a sports odds and player props API (30+ sportsbooks plus Kalshi and Polymarket prediction markets).

Free tier details, per the contribution guidelines:

- 1,000 credits per month, free forever, not a trial
- No credit card required to sign up
- Includes live odds, player props, historical odds, and prediction market endpoints
- Also has fully keyless sandbox and calculator endpoints for trying it without an account

Disclosure: I am the founder of ParlayAPI.

Placed alphabetically in the APIs, Data, and ML section (before Parseur). Link verified live today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)