### PR TITLE
Add JarPeek to Code Search and Browsing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
 ## Code Search and Browsing
 
   * [CodeKeep](https://codekeep.io) - Google Keep for Code Snippets. Organize, Discover, and share code snippets, featuring a powerful code screenshot tool with preset templates and a linking feature.
+  * [JarPeek](https://jarpeek.com) - Free online JAR viewer and Java decompiler. Decompile .class, .jar, and .war files in your browser with Vineflower; bytecode, constant pool, and hex views. Files never leave your device.
   * [libraries.io](https://libraries.io/) - Search and dependency update notifications for 32 different package managers, free for open source
   * [Namae](https://namae.dev/) - Search various websites like GitHub, Gitlab, Heroku, Netlify, and many more for the availability of your project name.
   * [tickgit.com](https://www.tickgit.com/) - Surfaces `TODO` comments (and other markers) to identify areas of code worth returning to for improvement.


### PR DESCRIPTION
Adds [JarPeek](https://jarpeek.com) — a free online JAR viewer & Java decompiler — to the **Code Search and Browsing** section.

Why it fits the list:
- 100% free, no registration or account required
- Decompiles .class / .jar / .war in the browser (Vineflower in a Web Worker); also opens artifacts from Maven Central by coordinates
- Bytecode, constant pool, and hex views per class
- Files never leave the device — all processing is client-side

I've read the contribution guidelines; the service is free to use without signup.
