### PR TITLE
Add rasterly to Screenshot APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1626,6 +1626,7 @@ Update Time, five active automations, webhooks.
   * [ApiFlash](https://apiflash.com) - A screenshot API based on Aws Lambda and Chrome. Handles full page, captures timing, and viewport dimensions.
   * [microlink.io](https://microlink.io/) - It turns any website into data such as metatags normalization, beauty link previews, scraping capabilities, or screenshots as a service. 50 requests/day every day free.
   * [PhantomJsCloud](https://PhantomJsCloud.com) - Browser automation and page rendering.  Free Tier offers up to 500 pages/day.  Free Tier since 2017.
+  * [rasterly](https://rasterly.dev) - Screenshot, PDF and full-page rendering API (PNG/JPEG/PDF/GIF/MP4) from a URL or raw HTML, with an MCP server and x402 pay-per-call. Instant free-tier key with just an email.
   * [Renderwolf](https://ironfang.uk/renderwolf) - UK-based screenshot, PDF, image, QR code and clip rendering API with reusable templates and signed URLs. 250 free renders a month with no payment details needed to get started.
   * [screenshotbase.com](https://screenshotbase.com) - 300 free screenshots / month. Take screenshots from any url. Fast, free & scalable.
   * [screenshotlayer.com](https://screenshotlayer.com/) - Capture highly customizable snapshots of any website. Free 100 snapshots/month


### PR DESCRIPTION
Adds rasterly (https://rasterly.dev) to the Screenshot APIs section, alphabetically. It has a genuine instant free-tier key (email in, key out, not a time-limited trial), and renders URL/HTML to PNG/JPEG/PDF/GIF/MP4. Single-line addition.