### PR TITLE
Add Favicon.one to Design and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ Update Time, five active automations, webhooks.
   * [Canva](https://canva.com) - Free online design tool to create visual content.
   * [CodedThemes](https://codedthemes.com/) - Offers a well-crafted admin dashboard & and UI kits designed to simplify and speed up modern web development.
   * [Excalidraw](https://excalidraw.com/) - A free online drawing document web page with free save to local and export support.
+  * [Favicon.one](https://favicon.one/) - Free favicon generator that creates a complete icon set from text, emoji, SVG, or any image, plus a favicon checker and downloader; runs entirely in the browser.
   * [figma.com](https://www.figma.com) - Online, collaborative design tool for teams; free tier includes unlimited files and viewers with a max of 2 editors and three projects.
   * [Flows](https://flows.sh/) - A fully customizable product adoption platform for building onboarding and user engagement experiences. Free for up to 250 monthly tracked users.
   * [JoyDemo](https://joydemo.com) - Create interactive and clickable demos of your website or app. Free with unlimited demos and unlimited views.


### PR DESCRIPTION
Adds [Favicon.one](https://favicon.one/) to the **Design and UI** section.

Favicon.one is a free online favicon generator: it builds a complete favicon/icon set from text, emoji, SVG, or any image (PNG/JPG), and includes a favicon checker and a favicon downloader. No signup, no server-side processing — everything runs in the browser. Available in English, Chinese, Japanese, and Spanish.

Similar to the existing BrandIcons favicon entry, but focused on generating/validating your own icons rather than fetching third-party ones.