### PR TITLE
Add WebTerm Learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,7 @@ This list results from Pull Requests, reviews, ideas, and work done by 1600+ peo
   * [Roadmap.sh](https://roadmap.sh) - Free learning roadmaps covering all aspects of development from Blockchain to UX Design.
   * [The Odin Project](https://www.theodinproject.com/) - Free, open-source platform with a curriculum focused on JavaScript and Ruby for web development.
   * [W3Schools](https://www.w3schools.com/) - Offers free tutorials on web development technologies like HTML, CSS, JavaScript, and more.
+  * [WebTerm Learn](https://learn.webterm.app) - Learn the Linux terminal, Git and Vim in a simulated terminal in the browser. All 129 lessons are free; the first lesson of each course needs no account.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adds [WebTerm Learn](https://learn.webterm.app) to *Education and Career Development*.

WebTerm Learn teaches the Linux terminal, Git and Vim in a simulated terminal in the browser. What is free: all 129 lessons across 12 courses. The first lesson of each course needs no account; the rest need a free account to save progress. There is no paid tier. Contact page: https://learn.webterm.app/en/contact, privacy policy: https://learn.webterm.app/en/privacy.

Disclosure: I built it.

## Requirements

 * [x] This is Software as a Service not self hosted
 * [x] It has a free tier not just a free trial
 * [x] Pricing information is clearly visible without signup or phone calls
 * [x] The submission mentions what is free
 * [x] The submission is not already present in the list
 * [x] The service has contact details of those running it and a privacy policy

 * [ ] Large Language Models and other AI tick this box