### PR TITLE
Add Toolfyra (Miscellaneous): 341 free client-side web tools, no signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,6 +1660,8 @@ Update Time, five active automations, webhooks.
 
 ## Miscellaneous
 
+* [Toolfyra](https://toolfyra.com) — 341 free browser-based dev & utility tools (JSON/CSV/XML formatters, regex tester, JWT decoder, UUID/timestamp/base64, cron helper, PDF tools). No signup; everything runs client-side, files never leave the device.
+
   * [BinShare.net](https://binshare.net) - Create & share code or binaries. Available to share as a beautiful image e.g. for Twitter / Facebook post or as a link e.g. for chats or forums.
   * [Blynk](https://blynk.io) - A SaaS with API to control, build & evaluate IoT devices. Free Developer Plan with 5 devices, Free Cloud & data storage. Mobile Apps are also available.
   * [cron-job.org](https://cron-job.org) - Online cronjobs service. Unlimited jobs are free of charge.


### PR DESCRIPTION
Toolfyra offers 341 free tools that run entirely in the browser — no signup, no server processing, files never leave the device. Developer-relevant tools include JSON/CSV/XML formatters & converters, regex tester, JWT decoder, UUID generator, timestamp converter, base64/URL encoders, cron expression helper, hash generator and PDF utilities. Free forever with no limits.