### PR TITLE
Add PodNet - free 2GB no-signup file sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1373,6 +1373,8 @@ Update Time, five active automations, webhooks.
   * [MantleDB](https://mantledb.sh) - Anonymous JSON storage for scripts and tiny apps. No signup required; uses Master AID for updates and Read-Only RID for public fetching. Free tier includes 1 bucket (1MB limit) with a 72h inactivity scavenger policy.
   * [otixo.com](https://www.otixo.com/) - Encrypt, share, copy, and move all your cloud storage files from one place. The basic plan provides unlimited file transfer with 250 MB max. file size and allows five encrypted files
   * [packagecloud.io](https://packagecloud.io/) - Hosted Package Repositories for YUM, APT, RubyGem and PyPI.  Limited free plans and open-source plans are available via request
+  * [PodNet](https://podnet.in/upload) - Free file sharing up to 2 GB, no signup required.
+
   * [pcloud.com](https://www.pcloud.com/) - Cloud storage service. Up to 10 GB of free storage
   * [Pinata IPFS](https://pinata.cloud) - Pinata is the simplest way to upload and manage files on IPFS. Our friendly user interface and IPFS API make Pinata the easiest IPFS pinning service for platforms, creators, and collectors. 1 GB storage free, along with access to API.
   * [plot.ly](https://plot.ly/) - Graph and share your data. The free tier includes unlimited public files and ten private files


### PR DESCRIPTION
Adds [PodNet](https://podnet.in/upload) to the Storage & Media Processing section: free file sharing up to 2 GB with no signup, comparable to the existing file.io entry. Entry format matches surrounding bullets.